### PR TITLE
docs(fix-issue): close three gaps found on the skill's first real run

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -79,7 +79,10 @@ because its detail is not inline.
    Conditional: skip it outright for a class (c) structural defect, and say so.
    [`tests-and-validators.md`](references/tests-and-validators.md)
 6. **`/simplify` pass**, run by default; skipping needs all four triviality
-   conditions and must be declared.
+   conditions and must be declared. Once the fix and tests pass, the
+   coordinator spawns a fresh MID `fix-issue-simplifier` against the writer's
+   candidate SHA - never brief the writer to invoke it itself, since the
+   writer role carries no `Agent` tool and cannot spawn its own reviewer.
    [`writer-steps.md`](references/writer-steps.md)
 7. **Lint and tests.** Writer runs the mutating commands and commits; a LIGHT
    verifier re-runs the fixed block against the frozen SHA. CI owns the full

--- a/.claude/skills/fix-issue/references/gate-ratchet.md
+++ b/.claude/skills/fix-issue/references/gate-ratchet.md
@@ -76,6 +76,25 @@ x86_64. The verifier runs the same test without the regeneration environment
 variable against the candidate SHA, inspects the committed diff, and confirms no
 worktree change.
 
+## New fixture: check hardcoded corpus-digest tests too
+
+At least one test hardcodes a single digest over every `.mmd` under `examples/`
+(`tests/test_route_topology.py`, via a module-level `CORPUS` glob constant) and
+asserts the whole corpus parses to byte-identical resolved graphs. A new
+fixture placed anywhere that glob reaches moves that digest, and the test reds
+with no hint that the fixture, not a real regression, is the cause - a #1766
+verify pass shipped past this once because the LIGHT verifier's selector
+covered the touched module and the new fixture's own test, but not this
+corpus-wide one.
+
+Before adding a fixture, grep `tests/` for hardcoded long-hex digests keyed on
+a glob over `examples/**` or `tests/fixtures/**` (as opposed to an explicit,
+hand-written file list) and check each one. Recompute the digest yourself in
+your own worktree - do not copy a value out of a diagnosis writeup without
+re-deriving it - and update the hardcoded value in the same commit. If a
+regeneration script exists for the test, use it; `test_route_topology.py` has
+none, so the fix is a direct edit to the hardcoded literal.
+
 ## Adding or re-tiering a routing check
 
 A new `check_*` in `CHECK_REGISTRY`, or a change to an existing `GuardSpec`'s
@@ -84,6 +103,6 @@ Decide the tier before writing the check, regenerate under 3.11, and inspect the
 diff's shape: hundreds of changed goldens is expected for a broad tier and a
 signal you picked the wrong one for a narrow invariant.
 
-A new topology fixture therefore owes **three** committed artifacts, not one: the
-`.mmd`, its `GALLERY_ENTRIES`/`gallery.yaml` row (so the render-diff sees it),
-and this guard-trace golden.
+A new topology fixture therefore owes **four** committed artifacts, not one:
+the `.mmd`, its `GALLERY_ENTRIES`/`gallery.yaml` row (so the render-diff sees
+it), this guard-trace golden, and any hardcoded corpus-digest test above.

--- a/.claude/skills/fix-issue/references/worker-contract.md
+++ b/.claude/skills/fix-issue/references/worker-contract.md
@@ -43,6 +43,15 @@ Returning **blocked** against this schema is a valid, useful outcome. It is
 better than guessing, better than an unbounded loop, and better than silently
 narrowing your scope. Say precisely what would unblock you.
 
+**An anomaly you cannot explain is never a footnote on a pass.** A crash,
+a discrepancy, a result that surprises you, a claim you ran out of time to
+verify - if you cannot account for it, your verdict is **blocked** or **fail**,
+not "pass, pending investigation of X." A pass says the coordinator can act on
+your result without reading further; hedging inside one asks them to read
+further anyway, but under the wrong verdict. Report exactly what is
+unexplained and let the coordinator decide whether to re-route, dispatch a
+follow-up investigation, or accept the residual risk.
+
 ## Reading source
 
 Grep to the symbol, then read a window around it rather than the whole file: the

--- a/.claude/skills/fix-issue/references/writer-steps.md
+++ b/.claude/skills/fix-issue/references/writer-steps.md
@@ -19,11 +19,14 @@ A five-line change that introduces a branch, or threads an argument through
 three call sites, is not trivial. If you are weighing whether it qualifies, it
 does not: run the pass.
 
-After the fix and tests are passing, assign a fresh MID read-only worker to
-invoke the `pinin4fjords:simplify` skill on the changed code. It returns findings, proposed
-edits, and a pass/fail verdict without writing. Re-brief the worktree's sole
-writer to apply accepted suggestions and record them in a **separate** local
-candidate commit:
+After the fix and tests are passing, hand off your candidate SHA and report it
+ready for a simplify pass. **Do not try to invoke `/simplify` or spawn a
+reviewer yourself** - the writer role carries no `Agent` tool, so this step
+belongs to the coordinator. The coordinator assigns a fresh MID read-only
+`fix-issue-simplifier` against your SHA; it invokes the `pinin4fjords:simplify`
+skill and returns findings, proposed edits, and a pass/fail verdict without
+writing anything. When the coordinator routes accepted suggestions back to
+you, apply them and record them in a **separate** local candidate commit:
 
 ```
 refactor: tighten <area> after fix for #<N>
@@ -65,11 +68,12 @@ worker buys no signal. Run a local full suite only when it earns its cost:
 - explicit admin-merge preparation needs local full-suite confidence.
 
 One exception is genuinely full-corpus by construction: a new topology
-fixture's guard-trace golden, under "Generated-artifact gates" below.
+fixture's guard-trace golden and any hardcoded corpus-digest test, under
+"Generated-artifact gates" below.
 
 ### Generated-artifact gates
 
-Two distinct triggers, and the path is literal. The gate-coverage ratchet
+Three distinct triggers, and the path is literal. The gate-coverage ratchet
 scans `src/nf_metro/layout/routing/` **only** (`ROUTING_DIR` in
 `scripts/routing_gate_coverage.py`, with branch coverage scoped to it), so it
 trips on an `if`/`while` change inside that nested package, or on a new fixture
@@ -78,7 +82,11 @@ module, `ordering.py` - cannot trip it, so do not spend a worker checking
 defensively. The guard-trace golden is separate and trips on a **new** fixture under any discovered root:
 `tests/fixtures`, `tests/fixtures/topologies`, `examples`, `examples/topologies`,
 `examples/guide` (see `_discover_fixtures` in `tests/test_engine_guards_perf.py`).
-A test fixture placed under `tests/` reds it too. When either fires, each failure names a specific
-reconciliation you owe in this same PR. Do not hand-edit baselines to silence
-them. Procedure, verdicts, and the Python 3.11 pinning gotcha:
-[`gate-ratchet.md`](gate-ratchet.md).
+A test fixture placed under `tests/` reds it too. A third, easy-to-miss trigger
+is any test that hardcodes a corpus-wide digest over the same fixture roots
+(`tests/test_route_topology.py` is one) - it reds with no hint that a new
+fixture, not a real regression, moved the digest, and a targeted selector for
+just the new fixture or the touched module never runs it. When any of the
+three fires, each failure names a specific reconciliation you owe in this same
+PR. Do not hand-edit baselines to silence them. Procedure, verdicts, and the
+Python 3.11 pinning gotcha, plus the corpus-digest check: [`gate-ratchet.md`](gate-ratchet.md).


### PR DESCRIPTION
## Summary

Three fixes to the `fix-issue` skill's documentation, found on its first real
run (#1766 / PR #1778):

- **`/simplify` ownership.** Step 6 briefed the sole writer to spawn its own
  MID reviewer, but `fix-issue-writer` carries no `Agent` tool, so it can't.
  On #1766 the writer self-ran the pass instead, and only got an independent
  look after the coordinator noticed and spawned one separately. `SKILL.md`
  and `writer-steps.md` now say explicitly: the writer hands off and reports
  ready, the coordinator spawns `fix-issue-simplifier` against that SHA.
- **A fourth generated artifact.** `gate-ratchet.md` documented the
  gate-coverage ratchet and the guard-trace golden as the artifacts a new
  topology fixture can perturb, but not hardcoded corpus-digest tests
  (`tests/test_route_topology.py`). On #1766 a targeted local selector missed
  exactly this, and it was only caught by a follow-up diagnostic investigation
  triggered by an unrelated false alarm - it would otherwise have reached CI
  and cost a push/CI round. Added as a documented check, and the "three
  committed artifacts" a new fixture owes is now four.
- **No footnoted passes.** `worker-contract.md` let a worker report "pass,
  pending investigation of X" - which happened on #1766 when a LIGHT verifier
  flagged an unexplained xdist anomaly but still returned an overall pass.
  Added a rule: an unexplained anomaly is `blocked`/`fail`, never a caveat on
  a pass.

This is a documentation-only change to `.claude/skills/fix-issue/`; no
production code or tests touched.

## Test plan
- [x] `prek` hooks (whitespace, EOF, prettier) pass on the changed files
- N/A - no production code, no CI-relevant test surface
