### PR TITLE
docs(fix-issue): falsification traps and two shared-worktree hazards

### DIFF
--- a/.claude/skills/fix-issue/references/diagnosis.md
+++ b/.claude/skills/fix-issue/references/diagnosis.md
@@ -106,6 +106,21 @@ Step 9 narrowing must gate code on a structural precondition, never reword the
 input. If the writer proposes an input workaround during an engine fix, stop
 and route the evidence back through diagnosis.
 
+### Two falsification traps
+
+Confirming the fix against a reduced repro that clears the *first* violation
+is not falsification if the issue's repro names more than one - a second,
+unrelated defect can sit behind the first (often an authoring mistake in the
+reporter's own `.mmd`) and only shows up when the post-diagnosis gate reruns
+the literal repro. Test against the complete repro, not a reduced one.
+
+A rendered-corpus zero-diff shows the change moved no pixel; it does not show
+the change is *right* if the corpus has no case where the changed decision
+could actually disagree with itself (e.g. a single-line bundle has no order
+to violate, so reclassifying its seam is inert). Check the corpus contains a
+case that could reveal a wrong answer, or build one, before citing zero-diff
+as safety evidence.
+
 ### Diagnostic tooling
 
 The repo bundles two scripts that do exactly this render-and-read-the-numbers

--- a/.claude/skills/fix-issue/references/environment.md
+++ b/.claude/skills/fix-issue/references/environment.md
@@ -46,6 +46,17 @@ never editable-install a shared env against a worktree.)
 Python 3.11 is the pinned interpreter for the routing/TB ratchets; those tests
 skip silently off it (see [gate-ratchet.md](gate-ratchet.md)).
 
+Take a corpus A/B render diff in one script invocation or one continuous
+worker turn: the shared `nf-metro-dev` env can be updated by a concurrent
+session between two separately-dispatched measurement passes, producing a
+near-total false diff that costs a full re-measurement to disprove.
+
+## Never `git stash` in a fix-issue worktree
+
+`refs/stash` is shared across every worktree of this repo, so a `pop` here can
+hand back a concurrent session's entry instead of yours, conflicting against
+changes you never made. Use a throwaway commit instead.
+
 ## Commit hooks
 
 Hooks need the tools on `PATH` in the same Bash call: the repo uses `prek`


### PR DESCRIPTION
## Summary
- `diagnosis.md`: adds "Two falsification traps" - confirming a fix against a reduced repro that clears only the first of several named violations is not falsification (a second, unrelated defect can hide behind it); and a corpus zero-diff is evidence the change is inert on that corpus, not evidence it's correct, unless the corpus actually contains a case the changed decision could get wrong.
- `environment.md`: notes a corpus A/B render diff must be measured in one window, since the shared `nf-metro-dev` env can be mutated by a concurrent session between two separately-dispatched measurement passes; and adds "Never `git stash` in a fix-issue worktree" since `refs/stash` is shared across all worktrees of one repo, so a `pop` can return another session's entry.

All three came from a single real run (#1767's fix): the post-diagnosis review gate caught the falsification-against-a-reduced-repro gap; the writer hit both the env-drift false corpus diff and a near-miss stash collision with another concurrent session, and reported them as risks worth capturing in the skill.

Kept deliberately small - a related third gap (the writer substituting an inline self-review for the independent `/simplify` pass) turned out to already be fixed by #1779, so no edit was needed there.

Fixes nothing on its own; process-only change to `.claude/skills/fix-issue/`.

## Test plan
- [x] `prek run --files` on the changed files (prettier, trailing-whitespace, eof-fixer) - clean
- [x] No production code touched