### PR TITLE
docs(fix-issue): default to generalizing over stacking axis-specific mirrors

### DIFF
--- a/.claude/skills/fix-issue/references/worker-contract.md
+++ b/.claude/skills/fix-issue/references/worker-contract.md
@@ -72,10 +72,16 @@ where a narrow window is actively dangerous:
 - A one-sided predicate (LEFT vs RIGHT, TB vs BT) you're about to **mirror**
   rarely stands alone: grep its name for companions - reflection logic, guard
   eligibility, dispatch entries - that key off it too, and mirror all of them
-  together, not just the one your repro exercises. Check first whether
-  existing axis-generic machinery (`AxisFrame`, `axis_along`, and siblings)
-  already covers both sides; extending that beats adding a predicate you'll
-  need to keep in sync by hand.
+  together, not just the one your repro exercises.
+
+**Default to generalizing an existing one-sided solution, not stacking
+another mirror beside it.** Before writing a new LEFT/RIGHT or TB/BT variant
+of something that already exists for the other side, check whether it can
+instead become axis-generic (`AxisFrame`, `axis_along`, and siblings are the
+existing machinery for this). Write a new one-sided predicate only when
+generalizing is genuinely out of scope for this fix, and say so in one line -
+this project has already paid down this exact debt once, and a fix that
+quietly adds a third or fourth hand-mirrored variant is re-accumulating it.
 
 ## Judgment above your tier
 

--- a/.claude/skills/fix-issue/references/worker-contract.md
+++ b/.claude/skills/fix-issue/references/worker-contract.md
@@ -59,7 +59,7 @@ three biggest layout modules are 205k tokens together and the median function in
 them is 28 lines. A window of 1-3k tokens is normally right.
 
 **But do not under-read.** Reading costs about $0.05 a spawn; a wrong fix costs a
-narrowing round plus a CI cycle, roughly $50. When in doubt read more. Two cases
+narrowing round plus a CI cycle, roughly $50. When in doubt read more. Three cases
 where a narrow window is actively dangerous:
 
 - `routing/core.py` is a **first-match dispatcher**, so a handler read in
@@ -69,6 +69,13 @@ where a narrow window is actively dangerous:
 - A guard in `phases/guards.py` or `routing/invariants.py` is registered with a
   tier that decides its blast radius; the registration matters as much as the
   body.
+- A one-sided predicate (LEFT vs RIGHT, TB vs BT) you're about to **mirror**
+  rarely stands alone: grep its name for companions - reflection logic, guard
+  eligibility, dispatch entries - that key off it too, and mirror all of them
+  together, not just the one your repro exercises. Check first whether
+  existing axis-generic machinery (`AxisFrame`, `axis_along`, and siblings)
+  already covers both sides; extending that beats adding a predicate you'll
+  need to keep in sync by hand.
 
 ## Judgment above your tier
 


### PR DESCRIPTION
## Summary
- `worker-contract.md`'s "Reading source" section gets a third under-read trap: a one-sided predicate (LEFT/RIGHT, TB/BT) about to be mirrored usually has companions - reflection logic, guard eligibility, dispatch entries - keyed off the original by name, and mirroring the primary decision without them is invisible to a read of the function alone.
- Adds a stronger, separate rule: **default to generalizing an existing one-sided solution into an axis-generic one (`AxisFrame`, `axis_along`, and siblings) rather than stacking another hand-mirrored variant beside it.** Writing a new one-sided predicate is still allowed, but only with an explicit one-line reason that generalizing was out of scope for the fix - mirroring the skip-condition pattern `/simplify` already uses elsewhere in this skill, since a soft "check first" is exactly what gets skipped under time pressure.

Both came from the same real run (#1767's fix): the writer mirrored an existing LEFT-only predicate for the RIGHT case, and the pre-ready review gate caught that the mirror's companion call sites (a track-reflection function and a guard's eligibility gate) were still hard-coded to the LEFT-only predicate, so the new RIGHT case rendered wrong instead of correctly. This project has unified axis-specific machinery before specifically to stop this class of bug; the rule says so without naming that program's issue numbers, matching this file's existing style of stating the general shape rather than the specific incident.

## Test plan
- [x] `.claude/skills/fix-issue/scripts/check_skill.py` passes locally
- [x] `prek run --files` on the changed file - clean
- [x] No production code touched