### PR TITLE
docs(fix-issue): capture plan-time-check and writer-resumability lessons

### DIFF
--- a/.claude/skills/fix-issue-lessons/SKILL.md
+++ b/.claude/skills/fix-issue-lessons/SKILL.md
@@ -96,9 +96,12 @@ survived Steps 1-3.
    worked, or a short date-based slug if there wasn't one).
 2. Edit only files under `.claude/skills/fix-issue/`.
 3. Run `prek run --files` on the changed files - these are docs edits, no
-   test suite is relevant, and `.claude/skills/fix-issue/scripts/check_skill.py`
-   only scans that skill's own files, so it isn't triggered by an unrelated
-   skill edit.
+   test suite is relevant. Also run
+   `python .claude/skills/fix-issue/scripts/check_skill.py` locally: it scans
+   `fix-issue`'s own reference files, which is exactly what this skill edits,
+   and CI enforces it. It fails on prose that reads as a worker assignment
+   (`brief`, `spawn`, `assign` + a role noun) without a tier or "sole writer"
+   nearby - phrase around that rather than finding out from a red CI run.
 4. Commit, push, open a **non-draft** PR (no render preview applies to a
    docs-only change). PR body: one bullet per file changed, naming the
    incident class each edit addresses, and naming any candidate you dropped

--- a/.claude/skills/fix-issue/references/coordinator.md
+++ b/.claude/skills/fix-issue/references/coordinator.md
@@ -168,8 +168,8 @@ The writer is the only party that can see its own turn count, so
 handoff and to offer the split itself.
 
 A writer's session can also expire before its turn budget - resume can fail
-outright well under 200 turns. Treat that as expected: brief a fresh writer
-from the last candidate SHA rather than waiting on it.
+outright well under 200 turns. Treat that as expected: brief a fresh sole
+writer from the last candidate SHA rather than waiting on it.
 
 Use one candidate sequence throughout: the sole writer makes local candidate
 commit(s), runs mutation-capable hooks or generators, and hands off the exact

--- a/.claude/skills/fix-issue/references/coordinator.md
+++ b/.claude/skills/fix-issue/references/coordinator.md
@@ -167,12 +167,9 @@ The writer is the only party that can see its own turn count, so
 [`worker-contract.md`](worker-contract.md) requires it to report turns on every
 handoff and to offer the split itself.
 
-A writer's session can also become unresumable independent of its own turn
-count: if enough wall-clock time or other agent activity elapses before the
-coordinator resumes it, the resume call can fail outright even well under the
-200-turn budget. Treat that as expected, not a blocker - brief a fresh writer
-from the last candidate SHA, restating the prior findings it needs, rather
-than waiting on a session that will not come back.
+A writer's session can also expire before its turn budget - resume can fail
+outright well under 200 turns. Treat that as expected: brief a fresh writer
+from the last candidate SHA rather than waiting on it.
 
 Use one candidate sequence throughout: the sole writer makes local candidate
 commit(s), runs mutation-capable hooks or generators, and hands off the exact

--- a/.claude/skills/fix-issue/references/coordinator.md
+++ b/.claude/skills/fix-issue/references/coordinator.md
@@ -167,6 +167,13 @@ The writer is the only party that can see its own turn count, so
 [`worker-contract.md`](worker-contract.md) requires it to report turns on every
 handoff and to offer the split itself.
 
+A writer's session can also become unresumable independent of its own turn
+count: if enough wall-clock time or other agent activity elapses before the
+coordinator resumes it, the resume call can fail outright even well under the
+200-turn budget. Treat that as expected, not a blocker - brief a fresh writer
+from the last candidate SHA, restating the prior findings it needs, rather
+than waiting on a session that will not come back.
+
 Use one candidate sequence throughout: the sole writer makes local candidate
 commit(s), runs mutation-capable hooks or generators, and hands off the exact
 SHA. Independent read-only workers verify and review that SHA without changing

--- a/.claude/skills/fix-issue/references/diagnosis.md
+++ b/.claude/skills/fix-issue/references/diagnosis.md
@@ -57,13 +57,10 @@ that is open-ended judgment: the worker returns blocked naming the options in
 its `DECIDE` field, and the work re-routes to HIGH. A stated cause bounds
 *where to look*, not necessarily *how much there is to decide*.
 
-A `DECIDE` that is purely about visual magnitude or spacing (a padding value,
-a margin size) should not be resolved by asking the user to pick blind
-between numeric options before any render exists. Implement the
-cheaper-to-reason default, get a render in front of the user, and let
-inspection drive the final magnitude - a number chosen sight-unseen is
-exactly what a later visual-review round overturns, at the cost of another
-full writer round each time.
+Don't ask the user to pick a magnitude/spacing `DECIDE` (a padding, a margin)
+blind before a render exists - implement the cheaper default, get a render in
+front of them, let inspection set the number. A number chosen sight-unseen is
+what a later visual-review round overturns anyway.
 
 ### Check your premise against current `origin/main` first
 
@@ -103,14 +100,13 @@ Require the diagnostic worker to decide which of three things it is looking at:
 Record which one it is - in numbers for (a), (b) and (d), in named call sites
 for (c) - before briefing the writer.
 
-For a (b) engine bug that could be fixed either as a plan-time layout
-mechanism or a render-time post-hoc correction, check before briefing the
-writer: does an active architecture programme already cover this class of
-defect, explicitly exclude it, or leave it as unstarted groundwork (grep open
-issues and any stale branches for the relevant theme)? If a plan-time fix
-isn't achievable within this run's scope, say so explicitly rather than
-silently defaulting to the reactive mechanism, and file a tracking issue for
-the gap if nothing already covers it.
+**Default to a plan-time fix for (b); a render-time post-hoc correction needs
+a stated reason it's unavoidable, not just easier.** Before briefing the
+writer, check for an active architecture programme covering this defect class
+(grep open issues, stale branches). Brief the writer for plan-time unless a
+concrete blocker rules it out this run (an unstarted dependency, a
+stale/conflicting branch, a data-flow inversion needing its own PR) - name it
+in the handoff. File a tracking issue if the gap is untracked.
 
 ### Once it's an engine bug, the reproducer is frozen evidence
 

--- a/.claude/skills/fix-issue/references/diagnosis.md
+++ b/.claude/skills/fix-issue/references/diagnosis.md
@@ -57,6 +57,14 @@ that is open-ended judgment: the worker returns blocked naming the options in
 its `DECIDE` field, and the work re-routes to HIGH. A stated cause bounds
 *where to look*, not necessarily *how much there is to decide*.
 
+A `DECIDE` that is purely about visual magnitude or spacing (a padding value,
+a margin size) should not be resolved by asking the user to pick blind
+between numeric options before any render exists. Implement the
+cheaper-to-reason default, get a render in front of the user, and let
+inspection drive the final magnitude - a number chosen sight-unseen is
+exactly what a later visual-review round overturns, at the cost of another
+full writer round each time.
+
 ### Check your premise against current `origin/main` first
 
 Diagnose against latest remote, not a stale tree. The coordinator fetches
@@ -94,6 +102,15 @@ Require the diagnostic worker to decide which of three things it is looking at:
 
 Record which one it is - in numbers for (a), (b) and (d), in named call sites
 for (c) - before briefing the writer.
+
+For a (b) engine bug that could be fixed either as a plan-time layout
+mechanism or a render-time post-hoc correction, check before briefing the
+writer: does an active architecture programme already cover this class of
+defect, explicitly exclude it, or leave it as unstarted groundwork (grep open
+issues and any stale branches for the relevant theme)? If a plan-time fix
+isn't achievable within this run's scope, say so explicitly rather than
+silently defaulting to the reactive mechanism, and file a tracking issue for
+the gap if nothing already covers it.
 
 ### Once it's an engine bug, the reproducer is frozen evidence
 


### PR DESCRIPTION
## Summary
- `diagnosis.md`: default to a plan-time fix for a (b) engine bug; a render-time post-hoc correction needs a named blocker (unstarted dependency, stale/conflicting branch, data-flow inversion), not just convenience.
- `diagnosis.md`: don't resolve a visual magnitude/spacing `DECIDE` by asking the user to pick blind before a render exists - implement the cheaper default and let inspection set the number.
- `coordinator.md`: a writer's session can expire before its 200-turn handoff budget - resume can fail outright. Brief a fresh sole writer from the last candidate SHA rather than waiting on it.
- `fix-issue-lessons/SKILL.md`: corrected wording that said `check_skill.py` wouldn't be triggered by this skill's own edits - it always edits `fix-issue`'s own reference files, exactly what that checker scans. Discovered when this PR's first push tripped `skill-selfcheck` in CI on the writer-resumability bullet above (missing tier/"sole writer" phrasing); now run locally before pushing.

All surfaced during the #1769 canvas-growth fix (PR #1788). No candidates dropped as already-covered.

## Test plan
- [x] `prek run --files` on all changed files
- [x] `python .claude/skills/fix-issue/scripts/check_skill.py` passes locally