### PR TITLE
docs(fix-issue): pre-ready gate/CI parallelism, skip-ci footgun, PR body regen

### DIFF
--- a/.claude/skills/fix-issue/references/coordinator.md
+++ b/.claude/skills/fix-issue/references/coordinator.md
@@ -80,6 +80,11 @@ brief. Revise any later brief from its findings. The draft PR already exists
 from Step 8; this step adds no push and no new PR. Only after the gate passes
 may the coordinator run `gh pr ready <N>`.
 
+This gate reads the diff; it does not need the CI matrix to have finished. Run
+it as soon as the candidate SHA, its test evidence, and the render-diff/visual
+verdict are in hand, in parallel with a still-running CI - gate only the
+merge itself, not this review, on CI going green.
+
 A successful fix-issue run is not done when `/simplify` or a test worker
 returns. It reaches PR-ready completion when:
 

--- a/.claude/skills/fix-issue/references/merge-and-cleanup.md
+++ b/.claude/skills/fix-issue/references/merge-and-cleanup.md
@@ -16,6 +16,13 @@ tree, so the Step 8 provenance check fails and the fallback is to enumerate the
 corpus and render both sides locally. Use it for genuine throwaway snapshots;
 never on the commit you intend to review.
 
+If checks don't appear on a push meant to trigger CI within a couple of
+minutes, check that commit's message for a stray skip marker before assuming
+propagation delay - a commit whose prose even names or quotes the marker text
+can trip it (Actions scans the whole message), and a writer explaining an
+earlier skipped commit can reproduce this by accident. Recover with a new
+(never amended) commit that omits the marker.
+
 Read this at the push/merge/cleanup end of a run.
 
 ## Additive only - no force-push, ever
@@ -43,7 +50,11 @@ gh pr edit <PR_NUMBER> --body-file /tmp/pr-body.md
 ```
 
 The description should be a standalone summary of the current state of the diff
-against main - not a chronology of how the PR got there.
+against main - not a chronology of how the PR got there. When a PR goes
+through multiple rounds of D-delta narrowing, regenerate the summary against
+the full base..HEAD diff each time, not incrementally against just the latest
+round - otherwise earlier, already-reviewed deltas quietly drop out of the
+record and a fresh reviewer correctly flags the body as incomplete.
 
 If narrative comments already exist, the coordinator may sweep them via the
 GraphQL `deleteIssueComment` mutation only with issue/PR edit authority. **Keep**


### PR DESCRIPTION
## Summary

- `coordinator.md` (Step 11): the pre-ready gate reads the diff, evidence, and visual verdict - it doesn't need the CI matrix to be green first. Clarifies it can run in parallel with a still-running CI, gating only the actual merge on CI passing.
- `merge-and-cleanup.md` (When CI runs): a commit whose prose names or quotes the `[skip ci]` marker text can trip it by accident (Actions scans the whole message), silently preventing CI from ever triggering with no distinguishable symptom from ordinary propagation delay. Added a check-before-assuming-delay note.
- `merge-and-cleanup.md` (Narrative belongs in the PR description): when a PR goes through multiple rounds of D-delta narrowing, the summary needs regenerating against the full `base..HEAD` diff each time, not patched incrementally against just the latest round - otherwise earlier, already-reviewed deltas silently drop out of the record and a fresh pre-ready reviewer correctly flags the body as incomplete.

All three were real, generalizable incidents from a single fix-issue run on #1768 (three rounds of D-delta narrowing across a label-wrapping fix), not hypotheticals.

No candidates were dropped as already-covered - checked against latest `origin/main` (including the recent plan-time-check/writer-resumability lessons PR) before drafting.