### PR TITLE
fix(layout): reserve bundle edge clearance for a trunk port's own bundle

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -1263,9 +1263,12 @@ in pipeline order.
   below the deepest content (trunk alignment unaffected -- only
   bottom shrinks), and clear the lowest drawn lane of every port the box
   holds: `PERP_PORT_EDGE_INSET` for a perpendicular port, otherwise
-  `PERP_PORT_EDGE_CLEARANCE`, both measured from the port's outermost lane
-  rather than the port station (`port_bundle_edge_reach`).  For each row pair,
-  the row gap is `section_y_gap` (no more, no less, except where rowspan
+  `MIN_BUNDLE_EDGE_CLEARANCE` for a trunk port carrying a multi-line bundle,
+  which owes the edge the label room an interior station's bundle owes it.  Both
+  terms are measured from the port's outermost lane rather than the port station
+  (`port_bundle_edge_reach`), and a trunk port carrying a single line reserves
+  nothing here -- where it sits is the content padding's business.  For each
+  row pair, the row gap is `section_y_gap` (no more, no less, except where rowspan
   sections filled their full row claim).  A row pair claimed by
   `_merge_trunk_row_minimums` keeps that wider minimum between the two row
   *envelopes*: the trunk's channel crosses the whole boundary, so no
@@ -1325,8 +1328,9 @@ in pipeline order.
   section with an empty band (no port / bypass above content) the padding term
   is an equality, not just a floor: the excess band is reclaimed. Both port
   terms are measured from the port's outermost lane rather than the port
-  station (`port_bundle_edge_reach`), and a port the inset does not cover still
-  owes `PERP_PORT_EDGE_CLEARANCE` past that lane.
+  station (`port_bundle_edge_reach`), and a port the inset does not cover but
+  that carries a multi-line bundle owes `MIN_BUNDLE_EDGE_CLEARANCE` past that
+  lane, the same floor an interior station's bundle owes the edge.
 - **Invariants preserved**: Station Ys (only bbox tops move). Resolves #406.
 - **Related tests**: `test_section_bbox_has_top_padding`,
   `test_section_bbox_top_hugs_content`.

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -14,7 +14,7 @@ from nf_metro.layout.constants import (
     COORD_GROUP_DIGITS_FINE,
     COORD_TOLERANCE,
     COORD_TOLERANCE_FINE,
-    PERP_PORT_EDGE_CLEARANCE,
+    MIN_BUNDLE_EDGE_CLEARANCE,
     PERP_PORT_EDGE_INSET,
     PORT_BOUNDARY_CROSSING_TOL,
     SAME_COORD_TOLERANCE,
@@ -1806,17 +1806,23 @@ def port_edge_inset(
 
     On Y it is only a vertical flow's LEFT/RIGHT port.  A horizontal flow's
     LEFT/RIGHT port is its trunk arriving or leaving, not a run crossing the box,
-    so how far it sits from the top and bottom edges is the content padding's
-    business -- reserving against it instead grows a box into its neighbours.
+    so a single line through it owes the top and bottom edges nothing here: where
+    it sits is the content padding's business, and reserving against it instead
+    grows a box into its neighbours.
 
     ``lane_reach`` is how far the port's drawn bundle extends past the port
     station toward that edge (:func:`port_bundle_edge_reach`).  Both insets are
     room the outermost *drawn lane* owes the border rather than room the station
     owes it, so the reach adds on top: a bundle staggered 12px off its port would
-    otherwise leave its outer lane 12px short of what the inset advertises.  A
-    port the wider inset does not cover still owes
-    ``PERP_PORT_EDGE_CLEARANCE`` past its outermost lane, the floor
-    :func:`...guards._guard_ports_clear_unanchored_box_edges` enforces.
+    otherwise leave its outer lane 12px short of what the inset advertises.
+
+    A port the wider inset does not cover owes ``MIN_BUNDLE_EDGE_CLEARANCE`` past
+    its outermost lane whenever it carries a bundle at all: a multi-line trunk
+    crossing the box is drawn ink needing label room off the border, exactly as
+    an interior station's pill is (:func:`...bbox._bundle_edge_padding`).  That
+    is stricter than the ``PERP_PORT_EDGE_CLEARANCE`` floor
+    :func:`...guards._guard_ports_clear_unanchored_box_edges` enforces, the hard
+    runtime minimum for a lane of any kind.
     """
     if port is None:
         return 0.0
@@ -1827,7 +1833,7 @@ def port_edge_inset(
     elif axis == "x" and port.side in (PortSide.TOP, PortSide.BOTTOM):
         return reach + PERP_PORT_EDGE_INSET
     if reach:
-        return reach + PERP_PORT_EDGE_CLEARANCE
+        return reach + MIN_BUNDLE_EDGE_CLEARANCE
     return 0.0
 
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -90,6 +90,7 @@ from nf_metro.layout.phases._common import (
     iter_fold_lr_exits_short_of_target,
     iter_sole_trunk_continuations,
     line_forks_within_section,
+    port_bundle_edge_reach,
     section_axes,
     section_cross_axis,
     wrap_exit_carrier_anchor,
@@ -8115,6 +8116,12 @@ def test_section_bbox_padding_has_min_bundle_edge_clearance(fixture):
     smaller ``MIN_BUNDLE_EDGE_CLEARANCE`` floor, but every multi-line
     bundle in the corpus should clear at least that much so its label
     never crowds the section edge regardless of symmetry.
+
+    A horizontal flow's LEFT/RIGHT port is its trunk arriving or leaving, so
+    a bundle it carries is drawn ink inside the box just as a station's pill
+    is, and owes the same floor to the top and bottom edges.  TOP/BOTTOM
+    ports are pinned to the edge they sit on by construction, so a zero gap
+    there is correct and they are not checked.
     """
     from nf_metro.layout.constants import MIN_BUNDLE_EDGE_CLEARANCE
     from nf_metro.layout.routing import compute_station_offsets
@@ -8135,6 +8142,28 @@ def test_section_bbox_padding_has_min_bundle_edge_clearance(fixture):
             and sid not in port_ids
             and not graph.stations[sid].is_hidden
         ]
+        for pid in sorted(port_ids):
+            port = graph.ports.get(pid)
+            station = graph.stations.get(pid)
+            if station is None or port is None:
+                continue
+            if port.side not in (PortSide.LEFT, PortSide.RIGHT):
+                continue
+            low_reach, high_reach = port_bundle_edge_reach(graph, pid, offsets, "y")
+            if low_reach <= 0.0 and high_reach <= 0.0:
+                continue
+            top_gap = (station.y - low_reach) - sec.bbox_y
+            bot_gap = (sec.bbox_y + sec.bbox_h) - (station.y + high_reach)
+            if top_gap + tol < MIN_BUNDLE_EDGE_CLEARANCE:
+                offenders.append(
+                    f"section {sec.id!r} port {pid!r}: top gap={top_gap:.1f} "
+                    f"< MIN_BUNDLE_EDGE_CLEARANCE={MIN_BUNDLE_EDGE_CLEARANCE}"
+                )
+            if bot_gap + tol < MIN_BUNDLE_EDGE_CLEARANCE:
+                offenders.append(
+                    f"section {sec.id!r} port {pid!r}: bottom gap={bot_gap:.1f} "
+                    f"< MIN_BUNDLE_EDGE_CLEARANCE={MIN_BUNDLE_EDGE_CLEARANCE}"
+                )
         if not content_ids:
             continue
         for sid in content_ids:


### PR DESCRIPTION
## Summary
- `port_edge_inset` now reserves `MIN_BUNDLE_EDGE_CLEARANCE` (28px), not `PERP_PORT_EDGE_CLEARANCE` (10px), for a horizontal-flow (LR/RL) section's own trunk LEFT/RIGHT port when that port carries a real multi-line bundle. Previously that case fell through to the generic perpendicular-crossing floor, letting a bundled exit lane sit as close as 10px from the section box edge instead of the 28px an interior station's bundle already gets.
- Extends `test_section_bbox_padding_has_min_bundle_edge_clearance` to check bundle-carrying LR/RL trunk ports against both the top and bottom box edges (TOP/BOTTOM ports stay excluded - they're pinned to that edge by construction).
- Updates the `port_edge_inset` docstring and the Stage 6.13/6.15a postconditions in `CONTRACT.md` to state the corrected rule.

Corpus impact is narrow: one committed fixture (`examples/topologies/merge_adjacent_feeder.mmd`, section `source`) grows its box height by 18px to restore the 28px floor; no other section, station, or canvas size changes anywhere in the corpus (verified in the 326-entry CI render-diff and independently in a full geometry digest over routed polylines, bboxes, and station coordinates for all 340 fixtures).

The issue's motivating case (an uncommitted nf-core/riboseq map, from #1769) was independently reproduced and confirmed fixed: its `alignment` section's exit bundle clearance goes from 10px to 28px with the same single-rect blast radius.

**Not in scope here:** a single line through a port owes the box edges nothing under this rule (a port only reserves against its own bundle reach), so a single-line port sitting close to an edge set by unrelated content - e.g. `examples/genomeassembly_staggered.mmd`'s `scaffolding__exit_right_3`, 10px from a bottom the port didn't set - is unaffected by this change and is not this defect. Separately, a "bypass-V" routing term produces its own edge gaps (10 sections across the corpus, all at 20.0px) and is already deliberately scoped apart from this property by the Tier-A guard's own `narrow_reason` (`_guard_ports_clear_unanchored_box_edges`, pinned to #1494/#1540): "the wider question of how close any routed run may pass an edge it parallels is a separate property with its own threshold." Neither is touched by this PR.

Fixes #1773

## Test plan
- [x] Targeted tests pass locally (including the extended invariant test, confirmed red on base then green on the fix); CI matrix green on all Python versions (3.11/3.12/3.13)
- [x] `ruff check` + `ruff format --check` clean on whole repo
- [x] Runtime validator: none added - the property is a design target above the existing Tier-A guard's 10px hard floor, matching the established `PERP_PORT_EDGE_INSET` precedent (a corpus-ratchet pytest, not a second runtime guard on the same axis)
- [x] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1793/): exactly 1 of 326 renders changed
- [x] Render-preview verdict: Improvement (I) - `merge_adjacent_feeder`'s `source` section box grows to clear its exit bundle; no collateral defects