### PR TITLE
chore(fix-issue): pin HIGH-tier workers to claude-opus-4-8

### DIFF
--- a/.claude/agents/fix-issue-diagnostician.md
+++ b/.claude/agents/fix-issue-diagnostician.md
@@ -1,7 +1,7 @@
 ---
 name: fix-issue-diagnostician
 description: Diagnoses a defect for the fix-issue workflow, pinning it to a numeric claim (geometry) or named call sites (structural) before any code is written. Open-ended judgment.
-model: opus
+model: claude-opus-4-8
 tools: Bash, Read, Grep, Glob
 effort: high
 ---

--- a/.claude/agents/fix-issue-merge-assessor.md
+++ b/.claude/agents/fix-issue-merge-assessor.md
@@ -1,7 +1,7 @@
 ---
 name: fix-issue-merge-assessor
 description: Decides whether the unverified delta on a PR is genuinely CI-irrelevant, gating an authorised admin merge for the fix-issue workflow. Judgment on shipping unverified code.
-model: opus
+model: claude-opus-4-8
 tools: Bash, Read, Grep, Glob
 effort: high
 ---

--- a/.claude/agents/fix-issue-reviewer.md
+++ b/.claude/agents/fix-issue-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: fix-issue-reviewer
 description: The independent review gate for the fix-issue workflow, covering correctness, scope, invariants, safety, unresolved fallout, and aggregate progress in one pass.
-model: opus
+model: claude-opus-4-8
 tools: Bash, Read, Grep, Glob
 effort: high
 ---

--- a/.claude/agents/fix-issue-visual-reviewer.md
+++ b/.claude/agents/fix-issue-visual-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: fix-issue-visual-reviewer
 description: Judges a fix-issue render preview, classifying every changed example as improvement, neutral, or detrimental, and returns an acceptance verdict. Aesthetic judgment a validator cannot make.
-model: opus
+model: claude-opus-4-8
 tools: Bash, Read, Grep, Glob
 effort: high
 ---

--- a/.claude/agents/fix-issue-writer.md
+++ b/.claude/agents/fix-issue-writer.md
@@ -1,7 +1,7 @@
 ---
 name: fix-issue-writer
 description: The single writer for a fix-issue worktree. Writes the failing invariant test first, then the fix, runs mutation-capable generators and hooks, and hands off an exact candidate SHA.
-model: opus
+model: claude-opus-4-8
 tools: Read, Edit, Write, Bash, Grep, Glob, TodoWrite
 effort: high
 ---

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -120,7 +120,9 @@ nobody chose - and where it lands depends on the resolution order in
 that overrides every tier in this table. Never leave it to that.
 
 The tier is the contract, not the model name. On Claude Code that is
-`haiku`/`sonnet`/`opus`.
+`haiku`/`sonnet`/`claude-opus-4-8`. HIGH is pinned to that exact snapshot rather
+than the `opus` alias, so it does not silently follow Anthropic's newer Opus
+releases.
 
 **This skill is Claude Code specific and does not run elsewhere as written.** It
 leans on agent definitions, `Explore`/`Plan`, `effort`, `SendMessage` resumption,

--- a/.claude/skills/fix-issue/scripts/check_skill.py
+++ b/.claude/skills/fix-issue/scripts/check_skill.py
@@ -124,7 +124,7 @@ def table_tier_for(table: str, stem: str) -> str:
 
 def check_agent_definitions() -> None:
     """Definitions must parse, and their model must agree with the tier table."""
-    tier_model = {"LIGHT": "haiku", "MID": "sonnet", "HIGH": "opus"}
+    tier_model = {"LIGHT": "haiku", "MID": "sonnet", "HIGH": "claude-opus-4-8"}
     table = (SKILL / "SKILL.md").read_text()
     for a in sorted(AGENTS.glob("fix-issue-*.md")):
         head = a.read_text().split("---")[1]


### PR DESCRIPTION
## Summary
- Pins the fix-issue skill's 5 HIGH-tier agent definitions (writer, diagnostician, reviewer, merge-assessor, visual-reviewer) to the `claude-opus-4-8` model snapshot instead of the `opus` alias, so they stay on that generation instead of silently following newer Anthropic Opus releases.
- Updates `SKILL.md`'s tier documentation and `check_skill.py`'s tier-model map to match, keeping the skill's self-check consistent.

## Test plan
- [x] `python3 .claude/skills/fix-issue/scripts/check_skill.py` — passes (one pre-existing, unrelated failure: `anthropic`/`tiktoken` not installed for the token-budget check, reproduces identically on `main`)
- [x] Pre-commit hooks (trailing whitespace, prettier, mypy) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)