### PR TITLE
fix: keep a fork apex off a later fan's centreline

### DIFF
--- a/src/nf_metro/layout/fan_plans.py
+++ b/src/nf_metro/layout/fan_plans.py
@@ -1094,6 +1094,28 @@ def _grid_position(graph: MetroGraph, section_id: str) -> tuple[int, int]:
     return section.grid_col, section.grid_row
 
 
+def heads_its_own_fork(graph: MetroGraph, station_id: str) -> bool:
+    """Whether *station_id* stands at the head of a fan of its own.
+
+    Two or more on-track successors inside its own section make it the apex of
+    a fan ``assign_tracks`` has already centred it on, so its lane is settled
+    before any fan plan is built.  Ports, junctions, cross-section successors
+    and off-track outputs leave the apex free: none of them takes a lane out of
+    the section's own frame.
+    """
+    section_id = graph.section_for_station(station_id)
+    successors = {
+        edge.target
+        for edge in graph.edges_from(station_id)
+        if edge.target not in graph.ports
+        and edge.target not in graph.junction_ids
+        and graph.section_for_station(edge.target) == section_id
+        and (target := graph.stations.get(edge.target)) is not None
+        and not target.off_track
+    }
+    return len(successors) >= 2
+
+
 def _trunk_followers(
     graph: MetroGraph,
     fork_id: str,
@@ -1107,7 +1129,9 @@ def _trunk_followers(
     continues to after the join, and it stands on the fan's centreline.  Where a
     side reaches more than one station the trunk continues through none of them:
     those are the arms of a convergence or of a second fan, and putting them all
-    on one centreline would draw them in a single row.
+    on one centreline would draw them in a single row.  A station heading a fan
+    of its own is likewise no follower: it already holds the centre of that fan,
+    and this one's centreline is a branch lane away from it.
     """
 
     def _side(
@@ -1126,7 +1150,9 @@ def _trunk_followers(
                 if station_id not in found:
                     found.append(station_id)
                 break
-        return tuple(found) if len(found) == 1 else ()
+        if len(found) != 1 or heads_its_own_fork(graph, found[0]):
+            return ()
+        return tuple(found)
 
     return (
         *_side(fork_id, approach_paths, upstream=True),

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -5241,6 +5241,74 @@ def _straight_frame_fault(
     return None
 
 
+def _fan_plan_contract_fault(graph: MetroGraph) -> str | None:
+    """Which whole-graph fan-plan contract the set of plans breaks, if any.
+
+    Each of these faults is settled once the plans are built and before any
+    frame is realised, so they read the plan set rather than the coordinates.
+    """
+    from nf_metro.layout.fan_plans import heads_its_own_fork
+    from nf_metro.layout.route_plan import FanAppearancePolicy
+
+    invalid_policy = next(
+        (
+            plan
+            for plan in graph.fan_plans
+            if not isinstance(plan.appearance_policy, FanAppearancePolicy)
+        ),
+        None,
+    )
+    if invalid_policy is not None:
+        return (
+            f"fan {invalid_policy.id!s} has non-canonical appearance "
+            f"policy {invalid_policy.appearance_policy!r}"
+        )
+
+    reconvergences = [
+        plan
+        for plan in graph.fan_plans
+        if plan.owns_geometry and plan.authored_join_station_id is not None
+    ]
+    missing_join = next(
+        (plan for plan in reconvergences if plan.join_station_id is None), None
+    )
+    if missing_join is not None:
+        return f"planned reconvergence {missing_join.id!s} has no resolved join"
+
+    unsupported = next(
+        (
+            plan
+            for plan in reconvergences
+            if plan.appearance_policy is FanAppearancePolicy.STRAIGHT
+        ),
+        None,
+    )
+    if unsupported is not None:
+        return (
+            f"planned fan {unsupported.id!s} claims geometry for frozen "
+            f"appearance policy {unsupported.appearance_policy.value!r}"
+        )
+
+    # Trunk followers ride the fan's centreline, and a fork apex already holds
+    # the centre of the fan below it: one lane, seated twice.
+    claimed_apex = next(
+        (
+            (plan, station_id)
+            for plan in graph.fan_plans
+            for station_id in plan.trunk_follower_ids
+            if heads_its_own_fork(graph, station_id)
+        ),
+        None,
+    )
+    if claimed_apex is not None:
+        apex_plan, apex_id = claimed_apex
+        return (
+            f"fan {apex_plan.id!s} takes {apex_id!r} as a trunk follower, but it "
+            "heads a fan of its own and holds that fan's centre"
+        )
+    return None
+
+
 def _guard_planned_fan_frame_realised(
     graph: MetroGraph,
     phase: str,
@@ -5256,50 +5324,9 @@ def _guard_planned_fan_frame_realised(
     from nf_metro.layout.route_plan import FanAppearancePolicy, fan_lane_seat_keys
     from nf_metro.layout.routing.reversal import tb_positive_fan_sections
 
-    invalid_policy = next(
-        (
-            plan
-            for plan in graph.fan_plans
-            if not isinstance(plan.appearance_policy, FanAppearancePolicy)
-        ),
-        None,
-    )
-    if invalid_policy is not None:
-        raise PhaseInvariantError(
-            f"{phase}: fan {invalid_policy.id!s} has non-canonical appearance "
-            f"policy {invalid_policy.appearance_policy!r}"
-        )
-
-    missing_join = next(
-        (
-            plan
-            for plan in graph.fan_plans
-            if plan.owns_geometry
-            and plan.authored_join_station_id is not None
-            and plan.join_station_id is None
-        ),
-        None,
-    )
-    if missing_join is not None:
-        raise PhaseInvariantError(
-            f"{phase}: planned reconvergence {missing_join.id!s} has no resolved join"
-        )
-
-    unsupported = next(
-        (
-            plan
-            for plan in graph.fan_plans
-            if plan.owns_geometry
-            and plan.authored_join_station_id is not None
-            and plan.appearance_policy is FanAppearancePolicy.STRAIGHT
-        ),
-        None,
-    )
-    if unsupported is not None:
-        raise PhaseInvariantError(
-            f"{phase}: planned fan {unsupported.id!s} claims geometry for frozen "
-            f"appearance policy {unsupported.appearance_policy.value!r}"
-        )
+    contract_fault = _fan_plan_contract_fault(graph)
+    if contract_fault is not None:
+        raise PhaseInvariantError(f"{phase}: {contract_fault}")
 
     offset_step = graph_offset_step(graph)
     section_layers: dict[str, dict[str, int]] = {}

--- a/tests/test_fan_centreline_fork_apex_1842.py
+++ b/tests/test_fan_centreline_fork_apex_1842.py
@@ -1,0 +1,145 @@
+"""No fan may take a station that heads a fan of its own as a follower (#1842).
+
+``assign_tracks`` seats a station that forks to two or more on-track successors
+inside its section on the centre of *that* fan.  Trunk-follower discovery took
+the station one hop along a fan's approach or departure path without asking
+whether it already held such a centre, which put a fork apex on a second fan's
+centreline and dragged it off the row its own branches fan out from.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.constants import SAME_Y_TOLERANCE
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph
+
+FIXTURES = Path(__file__).parent / "fixtures"
+EXAMPLES = Path(__file__).parent.parent / "examples"
+
+# The `alignment` section of the nf-core/riboseq map: `umi_dedup` forks to
+# `genomecov` and `salmon_quant`, and `salmon_quant` forks again.
+RIBOSEQ = FIXTURES / "curve_invariant_repros" / "riboseq_inter_row_corridor.mmd"
+
+# A diamond whose trunk continues past the join into a fork apex, which reaches
+# the same trunk-follower discovery from the join side rather than the fork side.
+JOIN_SIDE_APEX = """\
+%%metro title: join-side apex
+%%metro diamond_style: symmetric
+%%metro line: l1 | Line one | #e6007e
+
+graph LR
+    subgraph s1 [Stage one]
+        a[A]
+        b[B]
+        c[C]
+        j[J]
+        k[K]
+        m[M]
+        n[N]
+
+        a -->|l1| b
+        a -->|l1| c
+        b -->|l1| j
+        c -->|l1| j
+        j -->|l1| k
+        k -->|l1| m
+        k -->|l1| n
+    end
+
+    subgraph s2 [Stage two]
+        z[Z]
+        y[Y]
+        z -->|l1| y
+    end
+
+    m -->|l1| z
+    n -->|l1| z
+"""
+
+# Maps whose fans reach an apex from the fork side (`riboseq_inter_row_corridor`,
+# `rnaseq_sections`), from the join side (`sarek_metro`, `epitopeprediction`), or
+# from both (`variantbenchmarking`).
+FAN_HEAVY_MAPS = [
+    RIBOSEQ,
+    EXAMPLES / "sarek_metro.mmd",
+    EXAMPLES / "epitopeprediction.mmd",
+    EXAMPLES / "rnaseq_sections.mmd",
+    EXAMPLES / "differentialabundance.mmd",
+    EXAMPLES / "variantbenchmarking.mmd",
+    EXAMPLES / "genomeassembly.mmd",
+    EXAMPLES / "longread_variant_calling.mmd",
+]
+
+
+def _laid_out(text: str) -> MetroGraph:
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, validate=False)
+    return graph
+
+
+def _fork_apexes(graph: MetroGraph) -> set[str]:
+    """Stations forking to two or more on-track successors in their own section.
+
+    Restated from graph primitives rather than imported from the layout, so the
+    assertion is not the production predicate checked against itself.
+    """
+    apexes: set[str] = set()
+    for station_id in graph.stations:
+        if station_id in graph.ports or station_id in graph.junction_ids:
+            continue
+        section_id = graph.section_for_station(station_id)
+        successors = {
+            edge.target
+            for edge in graph.edges_from(station_id)
+            if edge.target not in graph.ports
+            and edge.target not in graph.junction_ids
+            and graph.section_for_station(edge.target) == section_id
+            and (target := graph.stations.get(edge.target)) is not None
+            and not target.off_track
+        }
+        if len(successors) >= 2:
+            apexes.add(station_id)
+    return apexes
+
+
+def _apex_followers(graph: MetroGraph) -> list[tuple[str, str]]:
+    """``(plan fork, apex)`` for every fork apex a fan holds as a trunk follower."""
+    apexes = _fork_apexes(graph)
+    return [
+        (plan.fork_station_id, station_id)
+        for plan in graph.fan_plans
+        for station_id in plan.trunk_follower_ids
+        if station_id in apexes
+    ]
+
+
+@pytest.mark.parametrize("path", FAN_HEAVY_MAPS, ids=lambda p: p.stem)
+def test_no_fan_takes_a_fork_apex_as_a_trunk_follower(path: Path) -> None:
+    assert _apex_followers(_laid_out(path.read_text())) == []
+
+
+def test_join_side_trunk_follower_apex_is_not_claimed() -> None:
+    assert _apex_followers(_laid_out(JOIN_SIDE_APEX)) == []
+
+
+def test_fork_apex_keeps_the_section_trunk_row() -> None:
+    """`star -> umi_dedup` runs level, with the fan symmetric about the apex."""
+    graph = _laid_out(RIBOSEQ.read_text())
+    entry_y = next(
+        graph.stations[port_id].y
+        for port_id, port in graph.ports.items()
+        if port.section_id == "alignment" and port.is_entry
+    )
+    apex_y = graph.stations["umi_dedup"].y
+    assert abs(graph.stations["star"].y - entry_y) <= SAME_Y_TOLERANCE
+    assert abs(apex_y - entry_y) <= SAME_Y_TOLERANCE
+
+    above = graph.stations["genomecov"].y
+    below = graph.stations["salmon_quant"].y
+    assert abs((above + below) / 2 - apex_y) <= SAME_Y_TOLERANCE
+    assert abs(below - above) > SAME_Y_TOLERANCE


### PR DESCRIPTION
## Summary
- A fan-plan's trunk-follower discovery could claim a station as its own centreline member even when that station headed its own in-section fork, dragging an already-correctly-placed fork apex off the shared trunk (e.g. `umi_dedup` in the nf-core/riboseq `alignment` section).
- `fan_plans.py`: new `heads_its_own_fork(graph, station_id)`; `_trunk_followers._side` now rejects a candidate that heads its own fan, on both the fork side and the join side (both are exercised by real corpus fixtures — `sarek_metro`, `epitopeprediction`, `inter_row_corridor_overflow`, and 16 more; all render byte-identical before/after).
- `phases/guards.py`: new `_fan_plan_contract_fault(graph)` helper, extracted from `_guard_planned_fan_frame_realised` to absorb the existing plan-scan checks plus this new one (forced by a complexity limit; no new `GuardSpec`, so no guard-golden churn).
- New test `tests/test_fan_centreline_fork_apex_1842.py`.

Fixes #1842

## Test plan
- [x] Targeted tests pass locally (including new invariant test): `test_fan_centreline_fork_apex_1842.py`, `test_fan_plans.py`, `test_guard_registry_golden.py`, `test_guard_registry.py`, `test_topology_validation.py`, `test_routing_gate_coverage.py`, plus the fixture-referencing modules (`test_fused_cotravelling_lines_invariant.py`, `test_flat_seam_lane_inheritance_1833.py`, `test_single_line_cohort_marker_span_1833.py`) — independently re-verified against the frozen candidate SHA
- [x] ruff check + ruff format + mypy clean on touched files
- [x] Runtime validator added: `_fan_plan_contract_fault` now catches a plan claiming a fork-apex station as a centreline member
- [x] CI matrix green on all 15 checks (3.11/3.12/3.13 shards, lint, format, e2e, gate-coverage ratchet, render-diff, skill-selfcheck)
- [x] Blast radius measured independently twice on the full ~392-file render corpus: exactly 1 SVG changes (`tests/fixtures/curve_invariant_repros/riboseq_inter_row_corridor.mmd`), corrected to the expected geometry; 13 pre-existing render errors byte-identical both sides
- [x] Visual review: the one changed fixture is **not** registered in the gallery/render-diff corpus (deliberately excluded per #1829 — the real map carries other, separately-filed defects), so the CI render-diff correctly reports no changes. Reviewed independently outside the gallery: classified **improvement** — `star -> umi_dedup` now runs on one collinear trunk row with `genomecov`/`salmon_quant` forking off symmetrically (±58.4px), replacing the prior 116.8px climb; `check_route_segment_crossings` 17→13, `check_exit_port_feeder_alignment` 8→5, no check gained violations. Two residuals reviewed and accepted: the bend moves to the `alignment`→`novel_transcripts` seam as a clean full-radius S (not a new kink), and `alignment`'s section-box top no longer levels with its row-0 neighbours (content-hugging, not overlap/clipping — a cosmetic-only note). No detrimental delta found anywhere, including the three real corpus maps (`sarek_metro`, `epitopeprediction`, `inter_row_corridor_overflow`) that exercise the new join-side rejection path.