### PR TITLE
fix(layout): release a section's bottom padding no row-mate genuinely shares

### DIFF
--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -650,46 +650,37 @@ def _shrink_bboxes_to_content_bottom(
     still bisects to a meaningful intermediate state.
     """
 
-    def _row_mate_bottoms(section: Section) -> list[float]:
-        # Two policies depending on this section's direction:
+    def _shares_bottom_with_row_mate(section: Section) -> bool:
+        # A bottom edge shared with a row-mate is deliberate -- Stage 6.5
+        # bottom-aligns row-mates, a TB fold's bbox is grown by
+        # ``section_y_gap`` so it reaches its target's bottom, and a rowspan
+        # section meets the bottom of the row it spans into -- so the shrink
+        # must leave it intact.  A row-mate that is merely deeper shares no
+        # edge with this section and must not hold its bottom off its content.
         #
-        # TB sections (folds) get their bbox grown by ``section_y_gap``
-        # in section_placement so they visually span into the next row's
-        # target.  Their intended bottom is the target row-mate's bottom,
-        # which is in a different grid row but Y-overlapping.  Honour
-        # Y-overlap for these so the bottom-alignment from Stage 6.5 /
-        # the fold extension survives.
-        #
-        # LR/RL sections use ONLY their STARTING grid row to find
-        # row-mates.  Counting this section's rowspan would pull in
+        # Membership itself has two policies.  LR/RL sections use ONLY their
+        # STARTING grid row: counting this section's rowspan would pull in
         # sections from rows the rowspan claims but doesn't fill -- a
-        # rowspan=2 LR sidebar whose content fits in row 0 must not be
-        # pinned to a row-1 neighbour just because its declared span
-        # overlaps row 1.  Y-overlap is intentionally excluded for
-        # LR/RL: a stale pre-shrink bbox would otherwise be
-        # self-protecting (the overlap blocks the shrink that would
-        # remove the overlap).
+        # rowspan=2 LR sidebar whose content fits in row 0 must not be pinned
+        # to a row-1 neighbour just because its declared span overlaps row 1.
+        # TB sections (folds), and any section without grid coords, take any
+        # section at the shared bottom: a fold's partner is by design in the
+        # next grid row down.
         my_grid_row = section.grid_row if section.grid_row >= 0 else None
-        my_y_top = section.bbox_y
         my_y_bot = section.bbox_y + section.bbox_h
-        # LR/RL sections with grid coords match on starting row only;
-        # TB sections (and any unplaced section) fall back to bbox-Y
-        # overlap.  See block comment above for the why.
         use_grid = section.direction != "TB" and my_grid_row is not None
-        out: list[float] = []
         for other in graph.sections.values():
             if other.id == section.id or other.bbox_h <= 0:
                 continue
             o_y_bot = other.bbox_y + other.bbox_h
-            if use_grid and my_grid_row is not None and other.grid_row >= 0:
-                o_grid_top = other.grid_row
-                o_grid_bot = other.grid_row + max(1, other.grid_row_span)
-                mate = o_grid_top <= my_grid_row < o_grid_bot
-            else:
-                mate = other.bbox_y < my_y_bot and o_y_bot > my_y_top
-            if mate:
-                out.append(o_y_bot)
-        return out
+            if abs(o_y_bot - my_y_bot) > SAME_COORD_TOLERANCE:
+                continue
+            if not use_grid or my_grid_row is None or other.grid_row < 0:
+                return True
+            o_grid_bot = other.grid_row + max(1, other.grid_row_span)
+            if other.grid_row <= my_grid_row < o_grid_bot:
+                return True
+        return False
 
     from nf_metro.layout.routing import compute_station_offsets
 
@@ -709,11 +700,9 @@ def _shrink_bboxes_to_content_bottom(
                 graph, section, PortSide.BOTTOM, section.bbox_y + section.bbox_h
             )
             continue
-        desired_bot = content_bot
-        mate_bots = _row_mate_bottoms(section)
-        if mate_bots:
-            desired_bot = max(desired_bot, max(mate_bots))
-        new_h = desired_bot - section.bbox_y
+        if _shares_bottom_with_row_mate(section):
+            continue
+        new_h = content_bot - section.bbox_y
         if new_h < section.bbox_h - SAME_COORD_TOLERANCE:
             section.bbox_h = max(0.0, new_h)
             _pull_section_ports_to_edge(

--- a/src/nf_metro/layout/routing/inter_section_handlers.py
+++ b/src/nf_metro/layout/routing/inter_section_handlers.py
@@ -3252,6 +3252,18 @@ def _bypass_geometry(
         ):
             base_y = corridor.bypass_band_y
 
+    # The step off the source leg down onto the trunk is two formed corners
+    # with a vertical run between them, so it needs a full radius of runway at
+    # each end.  A section bottom that leaves less than that -- the source
+    # already sitting most of the way down to the traverse's clearance lane --
+    # is deepened to exactly ``2 * curve_radius``, the shallowest step the
+    # corners can be drawn at without the bundle builder halving their radius.
+    src_leg_y = sy + src_off
+    step_runway = 2 * ctx.curve_radius
+    step = base_y + nest_offset - src_leg_y
+    if COORD_TOLERANCE < step < step_runway - COORD_TOLERANCE:
+        base_y = src_leg_y + step_runway - nest_offset
+
     # Determine actual vertical direction at each gap from the geometry.
     # Gap1 goes from source Y to trunk Y; gap2 from trunk Y to target Y.
     # Normally gap1 goes down and gap2 goes up, but when the source is

--- a/tests/riboseq_map.py
+++ b/tests/riboseq_map.py
@@ -1,0 +1,157 @@
+"""The nf-core/riboseq map source, shared by the tests that exercise it.
+
+Three grid-row-0 sections feed a four-section row 1 whose members have very
+different depths, which is what makes this map a dense source of row-mate
+padding, band-order and confluence cases.
+"""
+
+from __future__ import annotations
+
+RIBOSEQ_MMD = r"""%%metro title: nf-core/riboseq
+%%metro center_ports: true
+%%metro style: dark
+%%metro diamond_style: symmetric
+%%metro directional: true
+%%metro file: fastq_in | FASTQ
+%%metro file: hybrid_gtf_out | GTF | Hybrid GTF
+%%metro file: orf_catalogue | BED | ORF catalogue
+%%metro file: bigwig_out | BW | Coverage
+%%metro file: counts_out | TSV | Gene counts
+%%metro file: te_out | TSV | TE results
+%%metro file: report_final | HTML | MultiQC
+%%metro line: riboseq | Ribo-seq | #e6007e
+%%metro line: rnaseq | Matched RNA-seq | #2db572
+%%metro line: tiseq | TI-seq | #2b6cb0
+%%metro line: annotation | Hybrid annotation | #f2b407
+
+%%metro grid: preprocessing, alignment, novel_transcripts | 0,0
+%%metro grid: orf_calling, psite_id, te, reporting | 0,1
+%%metro x_spacing: 70
+%%metro legend: br
+
+graph LR
+    subgraph preprocessing [Read pre-processing]
+        fastq_in[ ]
+        umi_extract[UMI-tools extract]
+        fastp[fastp]
+        trimgalore[Trim Galore!]
+        bbsplit[BBSplit]
+        sortmerna[SortMeRNA]
+        ribodetector[RiboDetector]
+        bowtie2_rrna[Bowtie2]
+        fastqc[FastQC]
+        infer_strand[Infer strandedness]
+        equalise[Equalise\nread lengths]
+
+        fastq_in -->|riboseq,rnaseq,tiseq| umi_extract
+        umi_extract -->|riboseq,rnaseq,tiseq| fastp
+        umi_extract -->|riboseq,rnaseq,tiseq| trimgalore
+        fastp -->|riboseq,rnaseq,tiseq| bbsplit
+        trimgalore -->|riboseq,rnaseq,tiseq| bbsplit
+        bbsplit -->|riboseq,rnaseq,tiseq| sortmerna
+        bbsplit -->|riboseq,rnaseq,tiseq| ribodetector
+        bbsplit -->|riboseq,rnaseq,tiseq| bowtie2_rrna
+        sortmerna -->|riboseq,rnaseq,tiseq| fastqc
+        ribodetector -->|riboseq,rnaseq,tiseq| fastqc
+        bowtie2_rrna -->|riboseq,rnaseq,tiseq| fastqc
+        fastqc -->|riboseq,rnaseq,tiseq| infer_strand
+        infer_strand -->|riboseq,rnaseq,tiseq| equalise
+    end
+
+    subgraph alignment [Alignment & quantification]
+        star[STAR]
+        umi_dedup[UMI-tools dedup]
+        genomecov[BEDTools\ngenomecov]
+        salmon_quant[Salmon]
+
+        star -->|riboseq,rnaseq,tiseq| umi_dedup
+        umi_dedup -->|riboseq,rnaseq,tiseq| genomecov
+        genomecov -->|riboseq,rnaseq,tiseq| bigwig_out
+        umi_dedup -->|riboseq,rnaseq,tiseq| salmon_quant
+        salmon_quant -->|riboseq,rnaseq,tiseq| counts_out
+    end
+
+    subgraph novel_transcripts [Transcript discovery]
+        stringtie[StringTie]
+        gffcompare[gffcompare]
+        hybrid_merge[Merge &\nfilter GTF]
+
+        stringtie -->|rnaseq| gffcompare
+        gffcompare -->|rnaseq| hybrid_merge
+        hybrid_merge -->|rnaseq| hybrid_gtf_out
+    end
+
+    subgraph orf_calling [ORF discovery & calling]
+        star_hybrid[STAR:\nhybrid 2nd pass]
+        ribotish[Ribo-TISH]
+        ribocode[RiboCode]
+        ribotricer[Ribotricer]
+        rpbp[Rp-Bp]
+        price[PRICE]
+        orf_merge[Merge ORF\ncatalogue]
+
+        star_hybrid -->|riboseq| ribocode
+        ribotish -->|riboseq| orf_merge
+        ribocode -->|riboseq| orf_merge
+        ribotricer -->|riboseq| orf_merge
+        rpbp -->|riboseq| orf_merge
+        price -->|riboseq| orf_merge
+        orf_merge -->|riboseq| orf_catalogue
+    end
+
+    subgraph psite_id [P-site identification]
+        ribowaltz[riboWaltz]
+        plastid_psite[plastid\nP-site]
+        plastid_wiggle[plastid\nwiggle]
+        quantify_orf_psite[Quantify ORF\nP-sites]
+        psite_counts_gene[Gene in-frame\nP-sites]
+
+        ribowaltz -->|riboseq| quantify_orf_psite
+        plastid_psite -->|riboseq| plastid_wiggle
+        plastid_wiggle -->|riboseq| quantify_orf_psite
+        plastid_wiggle -->|riboseq| psite_counts_gene
+    end
+
+    subgraph te [Translational efficiency]
+        te_prep_gene[Gene count\nmatrix]
+        te_prep_orf[ORF count\nmatrix]
+        anota2seq[anota2seq]
+        deltate[DESeq2 deltaTE]
+        dotseq[DOTSeq]
+
+        te_prep_gene -->|riboseq,rnaseq| anota2seq
+        te_prep_gene -->|riboseq,rnaseq| deltate
+        te_prep_orf -->|riboseq,rnaseq| anota2seq
+        te_prep_orf -->|riboseq,rnaseq| deltate
+        te_prep_orf -->|riboseq,rnaseq| dotseq
+        anota2seq -->|riboseq,rnaseq| te_out
+        deltate -->|riboseq,rnaseq| te_out
+        dotseq -->|riboseq,rnaseq| te_out
+    end
+
+    subgraph reporting [Reporting]
+        multiqc_final[MultiQC]
+
+        multiqc_final -->|riboseq,rnaseq| report_final
+    end
+
+    equalise -->|riboseq,rnaseq,tiseq| star
+    equalise -->|riboseq| star_hybrid
+    umi_dedup -->|rnaseq| stringtie
+    umi_dedup -->|riboseq| ribotish
+    umi_dedup -->|riboseq| ribotricer
+    umi_dedup -->|riboseq| rpbp
+    umi_dedup -->|riboseq| price
+    umi_dedup -->|riboseq| ribowaltz
+    umi_dedup -->|riboseq| plastid_psite
+    orf_merge -->|riboseq| quantify_orf_psite
+    salmon_quant -->|rnaseq| te_prep_gene
+    salmon_quant -->|rnaseq| te_prep_orf
+    psite_counts_gene -->|riboseq| te_prep_gene
+    quantify_orf_psite -->|riboseq| te_prep_orf
+    anota2seq -->|riboseq,rnaseq| multiqc_final
+    hybrid_merge -->|annotation| star_hybrid
+    hybrid_merge -->|annotation| ribotish
+    hybrid_merge -->|annotation| ribotricer
+    hybrid_merge -->|annotation| ribocode
+"""

--- a/tests/riboseq_map.py
+++ b/tests/riboseq_map.py
@@ -3,6 +3,10 @@
 Three grid-row-0 sections feed a four-section row 1 whose members have very
 different depths, which is what makes this map a dense source of row-mate
 padding, band-order and confluence cases.
+
+It lives here rather than in the committed ``.mmd`` corpus because it also
+trips a symmetric-diamond centreline abort under ``validate=True`` in an
+unrelated section, which would red every corpus invariant that renders it.
 """
 
 from __future__ import annotations

--- a/tests/test_destination_port_eager_bundle.py
+++ b/tests/test_destination_port_eager_bundle.py
@@ -161,37 +161,29 @@ def test_same_destination_port_tail_keeps_three_axis_order(port_id: str) -> None
     assert port_order == expected_port
 
 
-def test_destination_tail_runtime_guard_is_not_vacuous(monkeypatch) -> None:
-    """The guard reports loose tails once the passes that settle them are off.
+def test_destination_tail_runtime_guard_is_not_vacuous() -> None:
+    """The guard reports a destination-tail bundle stacked in the wrong order.
 
-    Disabled here: normalize's own same-destination tail bundling, and the
-    convergent-line stagger at both of its live call sites (``core`` runs it
-    over the whole population, ``member_geometry`` over a planned one).
-    Member-geometry's own tail bundling still runs, so the tails this leaves
-    loose are the ones normalize would otherwise have settled.
+    Two lines converge on ``qc__entry_left_6`` from below-row trunks at
+    different depths, and their peel order earns them exactly that depth order.
+    Exchanging the two trunk Ys puts each line on the depth the other earns,
+    which is the defect the settling passes exist to prevent, so the guard must
+    name both lines.
     """
-    from nf_metro.layout.routing import core, member_geometry, normalize
-
     graph = parse_metro_mermaid(FIXTURE.read_text())
     compute_layout(graph)
     offsets = compute_station_offsets(graph)
-    monkeypatch.setattr(
-        normalize,
-        "_bundle_same_destination_tails",
-        lambda routes, ctx: None,
-    )
-    monkeypatch.setattr(
-        core,
-        "_stagger_convergent_distinct_lines",
-        lambda routes, ctx: None,
-    )
-    monkeypatch.setattr(
-        member_geometry,
-        "_stagger_convergent_distinct_lines",
-        lambda routes, ctx: None,
-    )
     routes = route_edges(graph, station_offsets=offsets)
+    assert not check_peeloff_concentric(graph, routes)
 
-    violations = check_peeloff_concentric(graph, routes)
-    messages = [violation.message() for violation in violations]
-    assert any("qc__entry_left_6" in message for message in messages)
+    tails = [route for route in routes if route.edge.target == "qc__entry_left_6"]
+    assert len(tails) == 2
+    trunk_ys = [list(iter_horizontal_trunks(route))[-1][1].y for route in tails]
+    for route, own_y, swapped_y in zip(tails, trunk_ys, reversed(trunk_ys)):
+        route.points[:] = [(x, swapped_y if y == own_y else y) for x, y in route.points]
+
+    messages = [
+        violation.message() for violation in check_peeloff_concentric(graph, routes)
+    ]
+    assert len(messages) == len(tails)
+    assert all("qc__entry_left_6" in message for message in messages)

--- a/tests/test_destination_port_eager_bundle.py
+++ b/tests/test_destination_port_eager_bundle.py
@@ -161,14 +161,17 @@ def test_same_destination_port_tail_keeps_three_axis_order(port_id: str) -> None
     assert port_order == expected_port
 
 
-def test_destination_tail_runtime_guard_is_not_vacuous() -> None:
-    """The guard reports a destination-tail bundle stacked in the wrong order.
+def test_destination_tail_guard_reports_a_depth_inverted_bundle() -> None:
+    """``check_peeloff_concentric`` names every line stacked against its order.
 
     Two lines converge on ``qc__entry_left_6`` from below-row trunks at
-    different depths, and their peel order earns them exactly that depth order.
-    Exchanging the two trunk Ys puts each line on the depth the other earns,
-    which is the defect the settling passes exist to prevent, so the guard must
-    name both lines.
+    different depths, and the settled routes put each on the depth its peel
+    order earns.  Exchanging the two trunk Ys constructs the inversion the
+    settling passes exist to prevent; the guard must then report both lines.
+
+    This is detector arithmetic over a hand-built input.  No corpus fixture
+    reaches the inversion through the routing pipeline, so the guard's ability
+    to see one is not otherwise exercised.
     """
     graph = parse_metro_mermaid(FIXTURE.read_text())
     compute_layout(graph)

--- a/tests/test_full_radius_turn_runway_1535.py
+++ b/tests/test_full_radius_turn_runway_1535.py
@@ -13,7 +13,7 @@ layout-level spacing, and aborting a render over a merely-tight arc would be
 worse than drawing it.  Holding the corpus to the stricter bar keeps the engine
 from regressing where it already achieves it.
 
-The two seatings that starved the runway are pinned individually below, so a
+The seatings that starved the runway are pinned individually below, so a
 regression names its own cause rather than surfacing as a clamped corner
 somewhere downstream.
 """
@@ -128,6 +128,27 @@ def test_bypass_descent_keeps_its_runway_into_the_entry_port() -> None:
     assert port_x - descent_x >= CURVE_RADIUS - _RADIUS_TOL, (
         f"descent column at x={descent_x:.0f} is {port_x - descent_x:.0f}px "
         f"from the port at x={port_x:.0f}"
+    )
+
+
+def test_bypass_trunk_step_keeps_its_runway_off_the_source_leg() -> None:
+    """The step down onto ``reference``'s bypass trunk spans two full radii.
+
+    The junction at ``input``'s RIGHT exit sits only a little above the
+    clearance lane under ``assemble``, so the step onto that trunk is short.
+    Two formed corners need ``2 * CURVE_RADIUS`` of vertical run between them,
+    and a shorter step halves both radii to fit.
+    """
+    graph, routes = _route(TOPOLOGIES / "packed_cell_right_exit_left_entry_wrap.mmd")
+    bypass = next(
+        rp
+        for rp in routes
+        if rp.edge.source == "__junction_10" and rp.edge.target == "annot__entry_left_9"
+    )
+    source_leg_y, trunk_y = bypass.points[1][1], bypass.points[2][1]
+    assert trunk_y - source_leg_y >= 2 * CURVE_RADIUS - _RADIUS_TOL, (
+        f"trunk at y={trunk_y:.0f} steps only {trunk_y - source_leg_y:.0f}px "
+        f"off a source leg at y={source_leg_y:.0f}"
     )
 
 

--- a/tests/test_merge_confluence_band_order_1835.py
+++ b/tests/test_merge_confluence_band_order_1835.py
@@ -7,10 +7,6 @@ inter-row band and one descent column.  ``check_merge_confluence_band_order``
 resolves each peel-off tail's port through the merge chain and flags a
 co-travelling distinct-line pair that ranks one way on the band and the other
 on the descent.
-
-The full map is inlined rather than committed as a fixture: it also trips a
-symmetric-diamond centreline abort under ``validate=True`` in an unrelated
-section, which would red every corpus invariant that renders it.
 """
 
 from __future__ import annotations
@@ -18,6 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from riboseq_map import RIBOSEQ_MMD
 
 from nf_metro.layout.engine import compute_layout
 from nf_metro.layout.routing import compute_station_offsets, route_edges_centred
@@ -32,157 +29,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES = REPO_ROOT / "examples"
 PORT = "orf_calling__entry_left_7"
 
-RIBOSEQ_CONFLUENCE = r"""%%metro title: nf-core/riboseq
-%%metro center_ports: true
-%%metro style: dark
-%%metro diamond_style: symmetric
-%%metro directional: true
-%%metro file: fastq_in | FASTQ
-%%metro file: hybrid_gtf_out | GTF | Hybrid GTF
-%%metro file: orf_catalogue | BED | ORF catalogue
-%%metro file: bigwig_out | BW | Coverage
-%%metro file: counts_out | TSV | Gene counts
-%%metro file: te_out | TSV | TE results
-%%metro file: report_final | HTML | MultiQC
-%%metro line: riboseq | Ribo-seq | #e6007e
-%%metro line: rnaseq | Matched RNA-seq | #2db572
-%%metro line: tiseq | TI-seq | #2b6cb0
-%%metro line: annotation | Hybrid annotation | #f2b407
-
-%%metro grid: preprocessing, alignment, novel_transcripts | 0,0
-%%metro grid: orf_calling, psite_id, te, reporting | 0,1
-%%metro x_spacing: 70
-%%metro legend: br
-
-graph LR
-    subgraph preprocessing [Read pre-processing]
-        fastq_in[ ]
-        umi_extract[UMI-tools extract]
-        fastp[fastp]
-        trimgalore[Trim Galore!]
-        bbsplit[BBSplit]
-        sortmerna[SortMeRNA]
-        ribodetector[RiboDetector]
-        bowtie2_rrna[Bowtie2]
-        fastqc[FastQC]
-        infer_strand[Infer strandedness]
-        equalise[Equalise\nread lengths]
-
-        fastq_in -->|riboseq,rnaseq,tiseq| umi_extract
-        umi_extract -->|riboseq,rnaseq,tiseq| fastp
-        umi_extract -->|riboseq,rnaseq,tiseq| trimgalore
-        fastp -->|riboseq,rnaseq,tiseq| bbsplit
-        trimgalore -->|riboseq,rnaseq,tiseq| bbsplit
-        bbsplit -->|riboseq,rnaseq,tiseq| sortmerna
-        bbsplit -->|riboseq,rnaseq,tiseq| ribodetector
-        bbsplit -->|riboseq,rnaseq,tiseq| bowtie2_rrna
-        sortmerna -->|riboseq,rnaseq,tiseq| fastqc
-        ribodetector -->|riboseq,rnaseq,tiseq| fastqc
-        bowtie2_rrna -->|riboseq,rnaseq,tiseq| fastqc
-        fastqc -->|riboseq,rnaseq,tiseq| infer_strand
-        infer_strand -->|riboseq,rnaseq,tiseq| equalise
-    end
-
-    subgraph alignment [Alignment & quantification]
-        star[STAR]
-        umi_dedup[UMI-tools dedup]
-        genomecov[BEDTools\ngenomecov]
-        salmon_quant[Salmon]
-
-        star -->|riboseq,rnaseq,tiseq| umi_dedup
-        umi_dedup -->|riboseq,rnaseq,tiseq| genomecov
-        genomecov -->|riboseq,rnaseq,tiseq| bigwig_out
-        umi_dedup -->|riboseq,rnaseq,tiseq| salmon_quant
-        salmon_quant -->|riboseq,rnaseq,tiseq| counts_out
-    end
-
-    subgraph novel_transcripts [Transcript discovery]
-        stringtie[StringTie]
-        gffcompare[gffcompare]
-        hybrid_merge[Merge &\nfilter GTF]
-
-        stringtie -->|rnaseq| gffcompare
-        gffcompare -->|rnaseq| hybrid_merge
-        hybrid_merge -->|rnaseq| hybrid_gtf_out
-    end
-
-
-    subgraph orf_calling [ORF discovery & calling]
-        star_hybrid[STAR:\nhybrid 2nd pass]
-        ribotish[Ribo-TISH]
-        ribocode[RiboCode]
-        ribotricer[Ribotricer]
-        rpbp[Rp-Bp]
-        price[PRICE]
-        orf_merge[Merge ORF\ncatalogue]
-
-        star_hybrid -->|riboseq| ribocode
-        ribotish -->|riboseq| orf_merge
-        ribocode -->|riboseq| orf_merge
-        ribotricer -->|riboseq| orf_merge
-        rpbp -->|riboseq| orf_merge
-        price -->|riboseq| orf_merge
-        orf_merge -->|riboseq| orf_catalogue
-    end
-
-    subgraph psite_id [P-site identification]
-        ribowaltz[riboWaltz]
-        plastid_psite[plastid\nP-site]
-        plastid_wiggle[plastid\nwiggle]
-        quantify_orf_psite[Quantify ORF\nP-sites]
-        psite_counts_gene[Gene in-frame\nP-sites]
-
-        ribowaltz -->|riboseq| quantify_orf_psite
-        plastid_psite -->|riboseq| plastid_wiggle
-        plastid_wiggle -->|riboseq| quantify_orf_psite
-        plastid_wiggle -->|riboseq| psite_counts_gene
-    end
-
-    subgraph te [Translational efficiency]
-        te_prep_gene[Gene count\nmatrix]
-        te_prep_orf[ORF count\nmatrix]
-        anota2seq[anota2seq]
-        deltate[DESeq2 deltaTE]
-        dotseq[DOTSeq]
-
-        te_prep_gene -->|riboseq,rnaseq| anota2seq
-        te_prep_gene -->|riboseq,rnaseq| deltate
-        te_prep_orf -->|riboseq,rnaseq| anota2seq
-        te_prep_orf -->|riboseq,rnaseq| deltate
-        te_prep_orf -->|riboseq,rnaseq| dotseq
-        anota2seq -->|riboseq,rnaseq| te_out
-        deltate -->|riboseq,rnaseq| te_out
-        dotseq -->|riboseq,rnaseq| te_out
-    end
-
-    subgraph reporting [Reporting]
-        multiqc_final[MultiQC]
-
-        multiqc_final -->|riboseq,rnaseq| report_final
-    end
-
-    %% Inter-section edges
-    equalise -->|riboseq,rnaseq,tiseq| star
-    equalise -->|riboseq| star_hybrid
-    umi_dedup -->|rnaseq| stringtie
-    umi_dedup -->|riboseq| ribotish
-    umi_dedup -->|riboseq| ribotricer
-    umi_dedup -->|riboseq| rpbp
-    umi_dedup -->|riboseq| price
-    umi_dedup -->|riboseq| ribowaltz
-    umi_dedup -->|riboseq| plastid_psite
-    orf_merge -->|riboseq| quantify_orf_psite
-    salmon_quant -->|rnaseq| te_prep_gene
-    salmon_quant -->|rnaseq| te_prep_orf
-    psite_counts_gene -->|riboseq| te_prep_gene
-    quantify_orf_psite -->|riboseq| te_prep_orf
-    anota2seq -->|riboseq,rnaseq| multiqc_final
-    hybrid_merge -->|annotation| star_hybrid
-    hybrid_merge -->|annotation| ribotish
-    hybrid_merge -->|annotation| ribotricer
-    hybrid_merge -->|annotation| ribocode
-"""
-
 
 def _route(text: str):
     graph = parse_metro_mermaid(text)
@@ -193,7 +39,7 @@ def _route(text: str):
 
 
 def test_riboseq_confluence_routes_without_band_descent_crossing() -> None:
-    graph, routes = _route(RIBOSEQ_CONFLUENCE)
+    graph, routes = _route(RIBOSEQ_MMD)
     reaching = {
         rp.line_id
         for rp in routes
@@ -214,7 +60,7 @@ def test_annotation_stays_outer_from_band_through_port_fan() -> None:
     band and descent stay outer crosses the two lines in the port throat, so the
     outer approach must carry through to the outer internal lane (#1835).
     """
-    graph, routes = _route(RIBOSEQ_CONFLUENCE)
+    graph, routes = _route(RIBOSEQ_MMD)
     offsets = compute_station_offsets(graph)
 
     band_y: dict[str, float] = {}
@@ -243,7 +89,7 @@ def test_annotation_stays_outer_from_band_through_port_fan() -> None:
 
 
 def test_check_catches_a_planted_confluence_crossing() -> None:
-    graph, routes = _route(RIBOSEQ_CONFLUENCE)
+    graph, routes = _route(RIBOSEQ_MMD)
     annotation = next(
         rp for rp in routes if rp.line_id == "annotation" and rp.edge.target == PORT
     )

--- a/tests/test_packed_row_mixed_fan_top_pad.py
+++ b/tests/test_packed_row_mixed_fan_top_pad.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from riboseq_map import RIBOSEQ_MMD
 
 from nf_metro.layout.engine import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
@@ -22,162 +23,13 @@ from nf_metro.parser.model import PortSide
 
 _EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
 
-_RIBOSEQ = """\
-%%metro title: nf-core/riboseq
-%%metro center_ports: true
-%%metro style: dark
-%%metro diamond_style: symmetric
-%%metro directional: true
-%%metro file: fastq_in | FASTQ
-%%metro file: hybrid_gtf_out | GTF | Hybrid GTF
-%%metro file: orf_catalogue | BED | ORF catalogue
-%%metro file: bigwig_out | BW | Coverage
-%%metro file: counts_out | TSV | Gene counts
-%%metro file: te_out | TSV | TE results
-%%metro file: report_final | HTML | MultiQC
-%%metro line: riboseq | Ribo-seq | #e6007e
-%%metro line: rnaseq | Matched RNA-seq | #2db572
-%%metro line: tiseq | TI-seq | #2b6cb0
-%%metro line: annotation | Hybrid annotation | #f2b407
-
-%%metro grid: preprocessing, alignment, novel_transcripts | 0,0
-%%metro grid: orf_calling, psite_id, te, reporting | 0,1
-%%metro x_spacing: 70
-%%metro legend: br
-
-graph LR
-    subgraph preprocessing [Read pre-processing]
-        fastq_in[ ]
-        umi_extract[UMI-tools extract]
-        fastp[fastp]
-        trimgalore[Trim Galore!]
-        bbsplit[BBSplit]
-        sortmerna[SortMeRNA]
-        ribodetector[RiboDetector]
-        bowtie2_rrna[Bowtie2]
-        fastqc[FastQC]
-        infer_strand[Infer strandedness]
-        equalise[Equalise\\nread lengths]
-
-        fastq_in -->|riboseq,rnaseq,tiseq| umi_extract
-        umi_extract -->|riboseq,rnaseq,tiseq| fastp
-        umi_extract -->|riboseq,rnaseq,tiseq| trimgalore
-        fastp -->|riboseq,rnaseq,tiseq| bbsplit
-        trimgalore -->|riboseq,rnaseq,tiseq| bbsplit
-        bbsplit -->|riboseq,rnaseq,tiseq| sortmerna
-        bbsplit -->|riboseq,rnaseq,tiseq| ribodetector
-        bbsplit -->|riboseq,rnaseq,tiseq| bowtie2_rrna
-        sortmerna -->|riboseq,rnaseq,tiseq| fastqc
-        ribodetector -->|riboseq,rnaseq,tiseq| fastqc
-        bowtie2_rrna -->|riboseq,rnaseq,tiseq| fastqc
-        fastqc -->|riboseq,rnaseq,tiseq| infer_strand
-        infer_strand -->|riboseq,rnaseq,tiseq| equalise
-    end
-
-    subgraph alignment [Alignment & quantification]
-        star[STAR]
-        umi_dedup[UMI-tools dedup]
-        genomecov[BEDTools\\ngenomecov]
-        salmon_quant[Salmon]
-
-        star -->|riboseq,rnaseq,tiseq| umi_dedup
-        umi_dedup -->|riboseq,rnaseq,tiseq| genomecov
-        genomecov -->|riboseq,rnaseq,tiseq| bigwig_out
-        umi_dedup -->|riboseq,rnaseq,tiseq| salmon_quant
-        salmon_quant -->|riboseq,rnaseq,tiseq| counts_out
-    end
-
-    subgraph novel_transcripts [Transcript discovery]
-        stringtie[StringTie]
-        gffcompare[gffcompare]
-        hybrid_merge[Merge &\\nfilter GTF]
-
-        stringtie -->|rnaseq| gffcompare
-        gffcompare -->|rnaseq| hybrid_merge
-        hybrid_merge -->|rnaseq| hybrid_gtf_out
-    end
-
-    subgraph orf_calling [ORF discovery & calling]
-        star_hybrid[STAR:\\nhybrid 2nd pass]
-        ribotish[Ribo-TISH]
-        ribocode[RiboCode]
-        ribotricer[Ribotricer]
-        rpbp[Rp-Bp]
-        price[PRICE]
-        orf_merge[Merge ORF\\ncatalogue]
-
-        star_hybrid -->|riboseq| ribocode
-        ribotish -->|riboseq| orf_merge
-        ribocode -->|riboseq| orf_merge
-        ribotricer -->|riboseq| orf_merge
-        rpbp -->|riboseq| orf_merge
-        price -->|riboseq| orf_merge
-        orf_merge -->|riboseq| orf_catalogue
-    end
-
-    subgraph psite_id [P-site identification]
-        ribowaltz[riboWaltz]
-        plastid_psite[plastid\\nP-site]
-        plastid_wiggle[plastid\\nwiggle]
-        quantify_orf_psite[Quantify ORF\\nP-sites]
-        psite_counts_gene[Gene in-frame\\nP-sites]
-
-        ribowaltz -->|riboseq| quantify_orf_psite
-        plastid_psite -->|riboseq| plastid_wiggle
-        plastid_wiggle -->|riboseq| quantify_orf_psite
-        plastid_wiggle -->|riboseq| psite_counts_gene
-    end
-
-    subgraph te [Translational efficiency]
-        te_prep_gene[Gene count\\nmatrix]
-        te_prep_orf[ORF count\\nmatrix]
-        anota2seq[anota2seq]
-        deltate[DESeq2 deltaTE]
-        dotseq[DOTSeq]
-
-        te_prep_gene -->|riboseq,rnaseq| anota2seq
-        te_prep_gene -->|riboseq,rnaseq| deltate
-        te_prep_orf -->|riboseq,rnaseq| anota2seq
-        te_prep_orf -->|riboseq,rnaseq| deltate
-        te_prep_orf -->|riboseq,rnaseq| dotseq
-        anota2seq -->|riboseq,rnaseq| te_out
-        deltate -->|riboseq,rnaseq| te_out
-        dotseq -->|riboseq,rnaseq| te_out
-    end
-
-    subgraph reporting [Reporting]
-        multiqc_final[MultiQC]
-
-        multiqc_final -->|riboseq,rnaseq| report_final
-    end
-
-    equalise -->|riboseq,rnaseq,tiseq| star
-    equalise -->|riboseq| star_hybrid
-    umi_dedup -->|rnaseq| stringtie
-    umi_dedup -->|riboseq| ribotish
-    umi_dedup -->|riboseq| ribotricer
-    umi_dedup -->|riboseq| rpbp
-    umi_dedup -->|riboseq| price
-    umi_dedup -->|riboseq| ribowaltz
-    umi_dedup -->|riboseq| plastid_psite
-    orf_merge -->|riboseq| quantify_orf_psite
-    salmon_quant -->|rnaseq| te_prep_gene
-    salmon_quant -->|rnaseq| te_prep_orf
-    psite_counts_gene -->|riboseq| te_prep_gene
-    quantify_orf_psite -->|riboseq| te_prep_orf
-    anota2seq -->|riboseq,rnaseq| multiqc_final
-    hybrid_merge -->|annotation| star_hybrid
-    hybrid_merge -->|annotation| ribotish
-    hybrid_merge -->|annotation| ribotricer
-    hybrid_merge -->|annotation| ribocode
-"""
 
 _TOL = 1.0
 
 
 @pytest.fixture(scope="module")
 def graph():
-    laid_out = parse_metro_mermaid(_RIBOSEQ)
+    laid_out = parse_metro_mermaid(RIBOSEQ_MMD)
     compute_layout(laid_out, validate=False)
     return laid_out
 

--- a/tests/test_section_bottom_padding_row_mate_pin_1853.py
+++ b/tests/test_section_bottom_padding_row_mate_pin_1853.py
@@ -1,0 +1,98 @@
+"""A section's bbox bottom is released unless a row-mate shares that bottom.
+
+Stage 6.13 shrinks each section's bbox down onto its content, but declines to
+when a grid row-mate's bottom pins it.  The pin exists for sections that are
+*bottom-aligned* with a mate (a TB fold grown to span into the next row, a
+Stage 6.5 aligned pair, a rowspan sidebar): dropping their bottom would break a
+deliberately shared bottom edge.  A row-mate that merely happens to be deeper
+carries no such intent, and must not hold a section's bottom above its content.
+
+The riboseq map has both in one grid row: ``orf_calling`` is much the deepest
+member and shares its bottom with nobody, so ``te`` and ``psite_id`` must hug
+their own content.  The preservation fixtures cover the three shapes where the
+pin is meant to fire.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from riboseq_map import RIBOSEQ_MMD
+
+from nf_metro.layout.constants import SAME_COORD_TOLERANCE, SECTION_Y_PADDING
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.phases.bbox import _predict_section_content_bottom
+from nf_metro.layout.routing import compute_station_offsets
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+_EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+_TOL = 1.0
+
+
+def _layout(text: str):
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, validate=False)
+    return graph
+
+
+def _bbox_bottom(graph, section_id: str) -> float:
+    section = graph.sections[section_id]
+    return section.bbox_y + section.bbox_h
+
+
+def _content_excess(graph, section_id: str) -> float:
+    """Px of bbox below the section's content-hug target."""
+    section = graph.sections[section_id]
+    hug = _predict_section_content_bottom(
+        graph, section, SECTION_Y_PADDING, compute_station_offsets(graph)
+    )
+    assert hug is not None, section_id
+    return _bbox_bottom(graph, section_id) - hug
+
+
+@pytest.fixture(scope="module")
+def riboseq():
+    return _layout(RIBOSEQ_MMD)
+
+
+@pytest.mark.parametrize("section_id", ["te", "psite_id"])
+def test_shallow_row_mate_hugs_its_own_content(riboseq, section_id):
+    # te's terminus is lifted onto the join centreline and psite_id's stack is
+    # short; neither shares a bottom with anything, so the deepest row-mate
+    # (orf_calling) must not reserve a dead band beneath them.
+    assert _content_excess(riboseq, section_id) <= _TOL
+
+
+@pytest.mark.parametrize("section_id", ["orf_calling", "reporting"])
+def test_unpinned_row_mates_keep_hugging_content(riboseq, section_id):
+    assert _content_excess(riboseq, section_id) <= _TOL
+
+
+def test_row_bottoms_stay_independent(riboseq):
+    # The row is not a shared bottom band: four members, four bottoms.
+    bottoms = [
+        _bbox_bottom(riboseq, sid)
+        for sid in ("orf_calling", "psite_id", "te", "reporting")
+    ]
+    assert len(set(round(b, 1) for b in bottoms)) == 4, bottoms
+
+
+@pytest.mark.parametrize(
+    "fixture,section_id,mate_id",
+    [
+        # TB fold grown by section_y_gap to reach its target's bottom.
+        ("topologies/fold_left_exit_right_entry", "middle", "report"),
+        # LR pair bottom-aligned within one grid row.
+        ("guide/05f_banner_labels", "analysis", "reporting"),
+        # Rowspan sidebar sharing the bottom of the row it spans into.
+        ("topologies/multirow_source_stacked_fan", "align_sec", "qc_sec"),
+    ],
+)
+def test_bottom_aligned_mate_still_pins(fixture, section_id, mate_id):
+    graph = _layout((_EXAMPLES / f"{fixture}.mmd").read_text())
+    section_bot = _bbox_bottom(graph, section_id)
+    # The pin is load-bearing here: without it the section would drop onto its
+    # own content, tearing the shared bottom edge.
+    assert _content_excess(graph, section_id) > _TOL
+    assert abs(section_bot - _bbox_bottom(graph, mate_id)) <= SAME_COORD_TOLERANCE


### PR DESCRIPTION
## Summary
- `_row_mate_bottoms` in `layout/phases/bbox.py` pinned a section's bottom to *any* row-mate's bottom, even one that merely happened to be deeper in the same grid row. Narrowed it to `_shares_bottom_with_row_mate`, which only pins when a mate's bottom is already within tolerance of this section's current bottom (the TB-fold / rowspan / Stage-6.5-aligned cases the pin exists for), letting an incidentally-deeper row-mate no longer block the shrink.
- `_bypass_geometry` in `routing/inter_section_handlers.py` gained a minimum corner-runway floor: reclaiming dead space could leave a bypass trunk step shorter than a formed corner's radius requires, halving its curve radius. The channel now deepens to exactly `2 * curve_radius` off the source leg when the natural step falls short. Without this, the bbox fix alone regressed `topologies/packed_cell_right_exit_left_entry_wrap` to a `SettledRouteValidationError`; with both commits applied together, that fixture nets out fine versus `main`.
- Consolidated the nf-core/riboseq map, previously duplicated verbatim across two test files, into a shared `tests/riboseq_map.py` fixture module.
- Retargeted `test_destination_tail_runtime_guard_is_not_vacuous` (renamed `test_destination_tail_guard_reports_a_depth_inverted_bundle`): its only real-pipeline witness in the corpus was the fixture this PR's routing fix corrects, so it now constructs the depth inversion directly instead of relying on a fixture accident, with a pipeline negative-control assertion kept alongside it.

Fixes #1853

## Test plan
- [x] New invariant test (`tests/test_section_bottom_padding_row_mate_pin_1853.py`) fails on `main`, passes on this branch
- [x] `tests/test_topology_validation.py` (glob-swept corpus) and full suite pass locally (55776 passed, 0 failed)
- [x] `ruff check` + `ruff format --check` clean on `src/` and `tests/`; `prek` hooks (incl. mypy) clean
- [x] CI green on all 15 checks (full test matrix, lint, format, e2e, routing gate coverage, render-diff, skill self-check)
- [x] CI render-diff reviewed render-by-render: `examples/differentialabundance` and `examples/variantbenchmarking_auto` lose dead bottom bands (improvement); `examples/showcase/seqinspector` (rendered under both its gallery stems) tightens 2.6px to its own content-hug target (neutral); `topologies/packed_cell_right_exit_left_entry_wrap` nets out to a correctly-formed, full-radius curve versus `main` (neutral/improvement - both commits are needed together, see above); `topologies/rowmate_tb_side_entry_top_align_grow` tightens to exactly its bypass-curve clearance floor, verified against five pre-existing corpus examples already at the same drawn clearance (neutral, not a violation)
- [x] riboseq map (the subject of #1853, not yet in the tracked gallery corpus per #1421) rendered directly on both SHAs: `te` bottom 674.0->615.6, `psite_id` 615.6->586.4, both now exactly 50px below their lowest marker; `orf_calling`/`reporting` unchanged
- [x] Render-preview verdict: accept as-is, no detrimental deltas, no narrowing precondition needed