### PR TITLE
fix(layout): fold bundle offset into bypass curve clearance floor

### DIFF
--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -509,6 +509,29 @@ def _bundle_edge_padding(
     )
 
 
+def _bypass_v_lane_reach(
+    graph: MetroGraph,
+    sid: str,
+    offsets: dict[tuple[str, str], float] | None,
+    is_horizontal: bool,
+) -> tuple[float, float]:
+    """How far above and below its anchor lane the curve drawn through
+    bypass-V helper ``sid`` reaches, as two non-negative distances.
+
+    A helper has no marker pill, but the diversion curve through it is drawn
+    on its line's offset lane (:func:`_station_bundle_offset_span`), which a
+    multi-line bundle can put a whole offset step off the anchor.  The
+    curve-clearance the section edge owes the helper is owed to that lane --
+    the bypass counterpart of what :func:`_bundle_edge_padding` does for a
+    marker's drawn pill.  A vertical-flow section separates its lines in X
+    instead, so both reaches are 0 there.
+    """
+    if not is_horizontal or offsets is None:
+        return 0.0, 0.0
+    min_off, max_off = _station_bundle_offset_span(graph, sid, offsets)
+    return max(0.0, -min_off), max(0.0, max_off)
+
+
 def _predict_section_content_bottom(
     graph: MetroGraph,
     section: Section,
@@ -528,6 +551,8 @@ def _predict_section_content_bottom(
     bottom-edge case of the bundle-span correction: how far a station's
     drawn bundle pill extends below its anchor lane
     (:func:`_station_bundle_offset_span`) folded into the padding target.
+    A bypass helper takes the same correction against its drawn curve
+    (:func:`_bypass_v_lane_reach`) under the smaller curve clearance.
     Pass a pre-computed ``offsets``
     (:func:`nf_metro.layout.routing.compute_station_offsets`) to avoid
     recomputing it once per section in a per-section caller's loop.
@@ -590,6 +615,7 @@ def _predict_section_content_bottom(
     content_bot = max(content_bots)
     bypass_max_ys = [
         graph.stations[sid].y
+        + _bypass_v_lane_reach(graph, sid, offsets, is_horizontal)[1]
         for sid in section.station_ids
         if sid in graph.stations and is_bypass_v(sid)
     ]
@@ -773,7 +799,9 @@ def _section_content_hug_top(
     bundle-span correction (see :func:`_bundle_edge_padding`): how far a
     multi-line bundle's drawn pill extends above its anchor lane
     (:func:`_station_bundle_offset_span`), which can be nonzero even when
-    no fan-out lifted the station itself.  Pass a pre-computed ``offsets``
+    no fan-out lifted the station itself.  A bypass helper takes the same
+    correction against its drawn curve (:func:`_bypass_v_lane_reach`) under
+    the smaller curve clearance.  Pass a pre-computed ``offsets``
     (:func:`nf_metro.layout.routing.compute_station_offsets`) to avoid
     recomputing it once per section in a per-section caller's loop.
 
@@ -818,6 +846,7 @@ def _section_content_hug_top(
     content_min_ys = [_content_min_y(sid) for sid in content_ids]
     bypass_min_ys = [
         graph.stations[sid].y
+        - _bypass_v_lane_reach(graph, sid, offsets, is_horizontal)[0]
         for sid in section.station_ids
         if sid in graph.stations and is_bypass_v(sid)
     ]

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -512,7 +512,7 @@ def _bundle_edge_padding(
 def _bypass_v_lane_reach(
     graph: MetroGraph,
     sid: str,
-    offsets: dict[tuple[str, str], float] | None,
+    offsets: dict[tuple[str, str], float],
     is_horizontal: bool,
 ) -> tuple[float, float]:
     """How far above and below its anchor lane the curve drawn through
@@ -526,7 +526,7 @@ def _bypass_v_lane_reach(
     marker's drawn pill.  A vertical-flow section separates its lines in X
     instead, so both reaches are 0 there.
     """
-    if not is_horizontal or offsets is None:
+    if not is_horizontal:
         return 0.0, 0.0
     min_off, max_off = _station_bundle_offset_span(graph, sid, offsets)
     return max(0.0, -min_off), max(0.0, max_off)

--- a/tests/test_bypass_v_curve_offset_clearance_1855.py
+++ b/tests/test_bypass_v_curve_offset_clearance_1855.py
@@ -1,0 +1,132 @@
+"""A bypass-V curve clears its section edge on the lane it is drawn on.
+
+A bypass helper carries no marker and no label, so its section box only has to
+clear the diversion curve rendered through it: ``CURVE_RADIUS +
+MIN_STATION_FLAT_LENGTH / 2``.  That curve is drawn on the helper's per-line
+lane, and a multi-line bundle puts that lane a whole offset step or more away
+from the helper's anchor Y, so the clearance only holds if it is measured
+against the drawn lane rather than the anchor.
+
+Measured from routed geometry with the render's own offset transform
+(:func:`apply_route_offsets`), independent of the bbox prediction that reserves
+the room.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.constants import CURVE_RADIUS, MIN_STATION_FLAT_LENGTH
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.common import apply_route_offsets
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph, is_bypass_v
+
+_ROOT = Path(__file__).resolve().parent.parent
+_V_CURVE_CLEARANCE = CURVE_RADIUS + MIN_STATION_FLAT_LENGTH / 2
+_TOL = 0.5
+
+# Every tracked fixture carrying a bypass-V helper in a section whose bbox the
+# helper can bind, plus fixtures whose helpers sit well inside their box as
+# controls that the floor is a floor and not a target.
+FIXTURES = [
+    "examples/guide/05_file_icons.mmd",
+    "examples/guide/06a_without_hidden.mmd",
+    "examples/guide/06b_with_hidden.mmd",
+    "examples/topologies/bypass_label_rake.mmd",
+    "examples/topologies/bypass_label_rake_left.mmd",
+    "examples/topologies/bypass_label_rake_wide.mmd",
+    "examples/topologies/bypass_v_tight.mmd",
+    "examples/topologies/inrow_skip_breeze.mmd",
+    "examples/topologies/rowmate_tb_side_entry_top_align_grow.mmd",
+    "examples/topologies/fan_branch_additional_outputs.mmd",
+    "examples/topologies/same_destination_short_overlap.mmd",
+    "tests/fixtures/da_pipeline.mmd",
+]
+
+
+def _layout(path: str) -> MetroGraph:
+    graph = parse_metro_mermaid((_ROOT / path).read_text())
+    compute_layout(graph)
+    return graph
+
+
+def _lane_clearances(graph: MetroGraph) -> list[tuple[str, str, float, float, float]]:
+    """``(section, helper, lane_y, top_clearance, bottom_clearance)`` per helper.
+
+    ``lane_y`` is where the diversion curve is actually drawn at the helper's
+    column, taken from the two routes the helper joins.
+    """
+    offsets = compute_station_offsets(graph)
+    drawn = [
+        ((route.edge.source, route.edge.target), apply_route_offsets(route, offsets))
+        for route in route_edges(graph, station_offsets=offsets)
+    ]
+    rows = []
+    for section in graph.sections.values():
+        if section.bbox_h <= 0:
+            continue
+        top = section.bbox_y
+        bottom = section.bbox_y + section.bbox_h
+        for sid in section.station_ids:
+            station = graph.stations.get(sid)
+            if station is None or not is_bypass_v(sid):
+                continue
+            lane_ys = [
+                y
+                for ends, points in drawn
+                if sid in ends
+                for x, y in points
+                if abs(x - station.x) <= _TOL
+            ]
+            if not lane_ys:
+                continue
+            rows.append(
+                (
+                    section.id,
+                    sid,
+                    max(lane_ys),
+                    min(lane_ys) - top,
+                    bottom - max(lane_ys),
+                )
+            )
+    return rows
+
+
+@pytest.mark.parametrize("fixture", FIXTURES, ids=[Path(f).stem for f in FIXTURES])
+def test_bypass_v_curve_clears_section_edges_on_its_drawn_lane(fixture: str):
+    graph = _layout(fixture)
+    rows = _lane_clearances(graph)
+    assert rows, f"{fixture} carries no measurable bypass-V helper"
+    offences = [
+        f"{section}/{helper}: top {top:.1f}, bottom {bot:.1f}"
+        for section, helper, _lane, top, bot in rows
+        if top < _V_CURVE_CLEARANCE - _TOL or bot < _V_CURVE_CLEARANCE - _TOL
+    ]
+    assert not offences, (
+        f"{fixture}: bypass-V curve drawn within {_V_CURVE_CLEARANCE:.0f}px of a "
+        f"section edge: " + "; ".join(offences)
+    )
+
+
+def test_offset_lane_is_what_binds_the_box():
+    """The lock is offset-sensitive, not just a restatement of the anchor rule.
+
+    ``processing``'s lower helper carries a bundle offset, so its drawn lane
+    sits below its anchor and the box has to reserve for the lane.  Without a
+    fixture where the two differ, the clearance assertion above would pass on
+    an anchor-only rule.
+    """
+    graph = _layout("examples/guide/06a_without_hidden.mmd")
+    rows = {
+        helper: (lane, bot)
+        for section, helper, lane, _top, bot in _lane_clearances(graph)
+        if section == "processing"
+    }
+    lane, bottom_clearance = rows["__bypass_quant_search_2"]
+    anchor = graph.stations["__bypass_quant_search_2"].y
+    assert lane > anchor + _TOL, (lane, anchor)
+    assert bottom_clearance >= _V_CURVE_CLEARANCE - _TOL


### PR DESCRIPTION
## Summary
- `_predict_section_content_bottom` and `_section_content_hug_top` (`src/nf_metro/layout/phases/bbox.py`) now fold a bypass-V curve helper's lateral bundle offset into its clearance-floor calculation, mirroring the offset fold already applied to marker stations.
- Previously the floor was computed from the helper's unoffset anchor `y`, so a helper carrying a bundle offset (e.g. +8px) could draw its curve with less than the intended runway off the section edge (12-16px drawn clearance against a 20px floor).
- New parametrized invariant test (`tests/test_bypass_v_curve_offset_clearance_1855.py`) asserts drawn clearance meets the intended floor for offset bypass-V helpers.

Fixes #1855

## Test plan
- [x] Targeted tests pass locally (new invariant test: 13 passed, 10/13 fail on base pre-fix; `test_topology_validation.py`, `test_section_bottom_padding_row_mate_pin_1853.py`, and 14 other layout/routing/render modules: all pass); CI matrix runs the full suite - all 15 jobs green
- [x] ruff check + ruff format clean on changed files
- [x] mypy clean on changed file
- [x] Runtime validator: not added separately - `_guard_section_bottom_padding` / its top twin call the two fixed functions directly, so the existing corpus-wide guard now enforces the offset-aware floor automatically
- [x] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1857/)
- [x] Render-preview verdict: 11 renders change (each grows a section by 4-8px to restore the bypass curve's runway); independent HIGH visual review classified all 11 as improvement or neutral, no detrimental deltas