### PR TITLE
feat(ci): ship the nf-metro pre-commit hook and trim the automation page to what exists

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: nf-metro
+  name: nf-metro (render metro map)
+  description: Re-render the metro-map SVG from its .mmd source.
+  entry: nf-metro render
+  language: python
+  files: \.mmd$
+  args: [--theme, nfcore, --embed-font]

--- a/docs/automation.mdx
+++ b/docs/automation.mdx
@@ -1,13 +1,12 @@
 ---
 title: "CI & automation"
-description: Keep a pipeline's metro-map SVG in sync with its .mmd source using the nf-metro GitHub Action, reusable workflow, or pre-commit hook.
+description: Keep a pipeline's metro-map SVG in sync with its .mmd source using the nf-metro GitHub Action or pre-commit hook.
 ---
 
 Commit a metro-map `.mmd` to your pipeline repo and let automation keep the
-rendered SVG in sync. nf-metro ships three integration modes:
+rendered SVG in sync. nf-metro ships two integration modes:
 
 - a **composite GitHub Action** — install + render, you decide what to do with the result;
-- a **reusable workflow** — the same, plus commit-on-push / warn-on-PR out of the box;
 - a **pre-commit hook** — re-render locally on every commit.
 
 ## GitHub Action
@@ -32,3 +31,29 @@ Inputs (all optional): `input` (default `assets/metro_map.mmd`), `output`
 `embed-font` (default `true`), `version` (nf-metro version to install), and
 `extra-args` for any other `nf-metro render` flag (e.g.
 `extra-args: "--fold-threshold 20"`).
+
+## Pre-commit hook
+
+Re-render the SVG locally on every commit, so it never drifts from the source.
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/seqeralabs/nf-metro
+    rev: 1.1.0
+    hooks:
+      - id: nf-metro
+```
+
+The hook matches `*.mmd` and writes the sibling `.svg`
+(`assets/metro_map.mmd` becomes `assets/metro_map.svg`). It runs with
+`--theme nfcore --embed-font` by default; setting `args` replaces that whole
+list, so repeat the flags you want to keep alongside the new one:
+
+```yaml
+- id: nf-metro
+  args: [--theme, nfcore, --embed-font, --mode, light]
+```
+
+Drop `--theme nfcore` if the map picks its own brand with a
+`%%metro style:` directive, which the flag would otherwise override.


### PR DESCRIPTION
`docs/automation.mdx` advertised three integration modes; only the composite action shipped. This adds the pre-commit hook and drops the mode that nothing implements.

## The hook

A root `.pre-commit-hooks.yaml` exposing id `nf-metro`: it matches `*.mmd`, runs `nf-metro render` with `--theme nfcore --embed-font`, and lets the CLI write the sibling `.svg` (`assets/metro_map.mmd` -> `assets/metro_map.svg`). Those defaults match the composite action's own `theme` / `embed-font` defaults, so both modes render the same thing.

Consumer config:

```yaml
# .pre-commit-config.yaml
repos:
  - repo: https://github.com/seqeralabs/nf-metro
    rev: 1.1.0
    hooks:
      - id: nf-metro
```

Setting `args` replaces the default list wholesale, so the docs spell out repeating the flags you want to keep (`args: [--theme, nfcore, --embed-font, --mode, light]`) and note that a map carrying `%%metro style:` wants `--theme nfcore` dropped, since the flag overrides the directive.

## Verification

From a scratch git repo holding a copy of `examples/rnaseq_sections.mmd` (plus the logo PNGs it references), against this branch's commit:

```
pre-commit try-repo /path/to/nf-metro nf-metro --files examples/rnaseq_sections.mmd
```

Result: `nf-metro (render metro map)......Passed`, with `examples/rnaseq_sections.svg` written next to the source (272 KB, `@font-face` block present, confirming `--embed-font` took effect).

## Docs

`docs/automation.mdx` loses the "reusable workflow" bullet and its mention in the frontmatter description (no such workflow exists on any branch), and gains a "Pre-commit hook" section. Version placeholders stay at `1.1.0`, matching the action snippet on the same page; the release skill bumps both.

Supersedes #1243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)