### PR TITLE
refactor: remove pre-release code residue

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -376,24 +376,11 @@ exceeds the curve radius by a meaningful amount so a visible flat is
 drawn through the station (matching how regular fork/join stations
 present a clear horizontal segment through their X coordinate)."""
 
-SECTION_ROUTE_CLEARANCE: float = 16.0
-"""Minimum gap between a section bbox edge and an external route channel.
-
-External routes (wrap channels, around routes, inter-row bypasses) choose
-their channel position relative to nearby section bboxes.  Without this
-floor the channel may sit one curve_radius + offset_step (~13 px) past
-the edge, which reads as flush against the section in renders.  This
-floor gives a small but visible breathing space.
-
-Kept as an alias of :data:`EDGE_TO_BUNDLE_CLEARANCE` (the principled
-"constant A" of the inter-section gap geometry) so legacy call sites
-continue to compile while the new geometry rolls out."""
-
 EDGE_TO_BUNDLE_CLEARANCE: float = 16.0
 """Constant A: minimum distance between a section bbox edge and the
-nearest line of an adjacent route bundle.
+nearest line of an adjacent route bundle or external route channel.
 
-Used as the single source of truth for two related clearances:
+Used as the single source of truth for three related clearances:
 
 - The leftmost (resp. rightmost) line of a bundle running vertically
   in an inter-section gap sits at least ``A`` from the right (resp.
@@ -403,9 +390,14 @@ Used as the single source of truth for two related clearances:
   the channel ever being pushed against a section edge.
 - Bypass / around-section routes maintain at least ``A`` from any
   intervening section's nearest edge.
+- An external route channel (a wrap channel, an around route, an
+  inter-row bypass) sits at least ``A`` beyond the bbox edge it runs
+  past.  Without the floor such a channel can land one curve radius
+  plus one offset step (~13 px) from the edge, which reads as flush
+  against the section."""
 
-Equal to :data:`SECTION_ROUTE_CLEARANCE` (the legacy name) so existing
-clearance code paths continue to honour the same physical distance."""
+SECTION_ROUTE_CLEARANCE: float = EDGE_TO_BUNDLE_CLEARANCE
+"""Alias of :data:`EDGE_TO_BUNDLE_CLEARANCE` for external-route call sites."""
 
 BUNDLE_TO_BUNDLE_CLEARANCE: float = 12.0
 """Constant B: minimum distance between two adjacent bundles sharing
@@ -517,9 +509,6 @@ TB_LINE_Y_OFFSET: float = 3.0
 
 ENTRY_SHIFT_TB: float = 1.0
 """Entry shift multiplier for TB sections with perpendicular entry."""
-
-ENTRY_INSET_LR: float = 0.3
-"""Entry inset multiplier for LR/RL sections with perpendicular entry."""
 
 ENTRY_SHIFT_LR: float = 0.5
 """Station shift multiplier for LR/RL sections with perpendicular entry.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -23,16 +23,14 @@ from functools import partial
 from nf_metro.layout.constants import (
     CURVE_RADIUS,
     DESCENDER_CLEARANCE,
+    EDGE_TO_BUNDLE_CLEARANCE,
     FONT_HEIGHT,
     ICON_STACK_LABEL_CLEARANCE,
     INTER_ROW_EDGE_CLEARANCE,
     LABEL_OFFSET,
     LABEL_OVERLAP_TOL,
     MIN_Y_SPACING_FLOOR,
-    ROW_GAP,
     SAME_COORD_TOLERANCE,
-    SECTION_GAP,
-    SECTION_ROUTE_CLEARANCE,
     SECTION_X_GAP,
     SECTION_X_PADDING,
     SECTION_Y_GAP,
@@ -451,7 +449,7 @@ def _far_side_wrap_left_clearances(graph: MetroGraph) -> dict[str, float]:
     a curve radius left of its box (see
     ``_route_left_exit_around_below_left_entry``).  Reserving that width as extra
     left extent lets the Stage 1.5 overshoot adjustment keep the wrap clear of
-    the canvas edge.  ``SECTION_ROUTE_CLEARANCE`` bounds the ascent channel's own
+    the canvas edge.  ``EDGE_TO_BUNDLE_CLEARANCE`` bounds the ascent channel's own
     edge clearance, so the sum is a safe upper bound on the wrap's reach.
     """
     clearances: dict[str, float] = {}
@@ -461,7 +459,10 @@ def _far_side_wrap_left_clearances(graph: MetroGraph) -> dict[str, float]:
         n = len({edge.line_id for edge in graph.edges_to(port.id)})
         offset_step = graph_offset_step(graph)
         clearance = (
-            (n - 1) * offset_step + CURVE_RADIUS + offset_step + SECTION_ROUTE_CLEARANCE
+            (n - 1) * offset_step
+            + CURVE_RADIUS
+            + offset_step
+            + EDGE_TO_BUNDLE_CLEARANCE
         )
         clearances[port.section_id] = max(
             clearances.get(port.section_id, 0.0), clearance
@@ -475,8 +476,6 @@ def compute_layout(
     y_spacing: float | None = None,
     x_offset: float = X_OFFSET,
     y_offset: float = Y_OFFSET,
-    row_gap: float = ROW_GAP,
-    section_gap: float = SECTION_GAP,
     section_x_padding: float = SECTION_X_PADDING,
     section_y_padding: float = SECTION_Y_PADDING,
     section_x_gap: float | None = None,

--- a/src/nf_metro/layout/route_plan.py
+++ b/src/nf_metro/layout/route_plan.py
@@ -137,7 +137,13 @@ class CoordinateRegime(str, Enum):
 
 
 class SettlementStage(str, Enum):
-    """Stable vocabulary for observing settlement progress."""
+    """Stable vocabulary for observing settlement progress.
+
+    A render emits only ``DISCOVERY``, ``GENERAL_SETTLEMENT``, ``COHORT_FINAL``
+    and ``VALIDATION``.  The other four members are reserved vocabulary that no
+    production path may emit, which
+    ``tests/test_corridor_cohort_integration.py`` asserts.
+    """
 
     DISCOVERY = "discovery"
     GENERAL_SETTLEMENT = "general-settlement"

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -23,7 +23,6 @@ from nf_metro.layout.constants import (
     MIN_CORRIDOR_Y_OVERLAP,
     OFFSET_STEP,
     SECTION_HEADER_PROTRUSION,
-    SECTION_ROUTE_CLEARANCE,
     graph_offset_step,
 )
 from nf_metro.layout.geometry import (
@@ -418,7 +417,7 @@ def header_corridor_y(
     full :data:`INTER_ROW_HEADER_CLEARANCE` applies only when a section
     occupies the gap above the row (contributing a header badge); the topmost
     row has only the canvas-top title band, so the smaller
-    :data:`SECTION_ROUTE_CLEARANCE` keeps the channel from overshooting it.
+    :data:`EDGE_TO_BUNDLE_CLEARANCE` keeps the channel from overshooting it.
 
     When *col* is given the channel clears only that grid column's sections, so
     a corridor leg confined to one column isn't pushed past a tall section
@@ -427,13 +426,13 @@ def header_corridor_y(
     if below:
         return (
             row_bottom_edge(graph, row, default=default, col=col)
-            + SECTION_ROUTE_CLEARANCE
+            + EDGE_TO_BUNDLE_CLEARANCE
             + base_radius
         )
     clearance = (
         INTER_ROW_HEADER_CLEARANCE
         if section_exists_above_row(graph, row)
-        else SECTION_ROUTE_CLEARANCE
+        else EDGE_TO_BUNDLE_CLEARANCE
     )
     return row_top_edge(graph, row, default=default, col=col) - clearance - base_radius
 

--- a/src/nf_metro/layout/routing/convergences.py
+++ b/src/nf_metro/layout/routing/convergences.py
@@ -67,6 +67,7 @@ from nf_metro.layout.routing.common import (
     HTrunkSeg,
     OffsetRegime,
     RoutedPath,
+    _points_coincide,
     _vert_horiz_cross,
     apply_route_offsets,
     column_gap_edges,
@@ -4685,13 +4686,6 @@ def _trunk_segments(
 def _route_covers_trunk(route: RoutedPath, axis: ConvergenceTrunkAxis) -> bool:
     return all(
         _route_covers_segment(route, start, end) for start, end in _trunk_segments(axis)
-    )
-
-
-def _points_coincide(first: tuple[float, float], second: tuple[float, float]) -> bool:
-    """Whether two points are the same point to within routing tolerance."""
-    return all(
-        abs(a - b) <= COORD_TOLERANCE for a, b in zip(first, second, strict=True)
     )
 
 

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import inspect
 import math
-import os
 import warnings
 from collections import defaultdict, deque
 from collections.abc import Callable, Collection, Iterable, Iterator, Sequence
@@ -6668,10 +6667,8 @@ def assert_render_curve_invariants(
     reached the renderer built some other way, and the fix is to route it
     through the builder too -- not to relax the check.
 
-    Set ``NF_METRO_ALLOW_BAD_CURVES=1`` to downgrade to a warning (debugging a
-    work-in-progress handler only; not a supported render mode). ``graph.permissive``
-    (``--permissive`` / ``%%metro permissive:``) downgrades the same way, as a
-    supported best-effort render mode.
+    ``graph.permissive`` (``--permissive`` / ``%%metro permissive:``) downgrades
+    the abort to a warning, as a supported best-effort render mode.
 
     A layout that bridges a perpendicular connection across grid columns (a
     ``direction:`` override -- explicit or inferred -- that feeds a section's
@@ -6806,7 +6803,7 @@ def assert_render_curve_invariants(
         "concentric_corner_radius_at and fan every leg consistently.\n  "
         f"{detail}"
     )
-    if graph.permissive or os.environ.get("NF_METRO_ALLOW_BAD_CURVES"):
+    if graph.permissive:
         warnings.warn(msg, category=PermissiveGuardWarning, stacklevel=2)
         return
     bridged = sorted(graph._cross_column_perp_bridges)

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -61,9 +61,6 @@ LEGEND_ROUTE_CLEARANCE: float = 6.0
 LOGO_Y_STANDALONE: float = 5.0
 """Y offset for standalone logo (no legend)."""
 
-LOGO_HEIGHT_DEFAULT: float = 80.0
-"""Default logo display height."""
-
 # ---------------------------------------------------------------------------
 # Legend
 # ---------------------------------------------------------------------------
@@ -114,11 +111,8 @@ SVG_CURVE_RADIUS: float = CURVE_RADIUS
 
 Derived from the layout CURVE_RADIUS so routing and rendering agree."""
 
-SECTION_NUM_CIRCLE_R: int = 8
-"""Radius of section number circle background (small variant)."""
-
 SECTION_NUM_CIRCLE_R_LARGE: int = 11
-"""Radius of section number circle background (large variant)."""
+"""Radius of the section number circle background."""
 
 SECTION_NUM_FONT_SIZE: int = 12
 """Font size for section number text inside the circle."""
@@ -187,12 +181,6 @@ MIN_ANIMATION_DURATION: float = 2.0
 
 EDGE_CONNECT_TOLERANCE: float = 1.0
 """Tolerance for detecting connected edge endpoints."""
-
-# ---------------------------------------------------------------------------
-# Icons
-# ---------------------------------------------------------------------------
-TRAIN_ICON_SIZE: float = 12.0
-"""Default size of train icon placeholder."""
 
 # ---------------------------------------------------------------------------
 # Debug overlay

--- a/src/nf_metro/render/icons.py
+++ b/src/nf_metro/render/icons.py
@@ -178,13 +178,6 @@ def _append_icon_banner_band(
     )
 
 
-def train_icon_path(x: float, y: float, size: float = 12.0) -> str:
-    """Generate an SVG path string for a small train icon. Placeholder for future."""
-    # Simple diamond shape as placeholder
-    hs = size / 2
-    return f"M {x} {y - hs} L {x + hs} {y} L {x} {y + hs} L {x - hs} {y} Z"
-
-
 def render_file_icon(
     d: draw.Drawing,
     cx: float,


### PR DESCRIPTION
Behaviour-neutral cleanup of code residue ahead of the release. No render output changes; no branch arms added or removed in `src/nf_metro/layout/routing/`, so the gate-coverage baseline is untouched.

## Removed / unified

- **One clearance constant, not two.** `SECTION_ROUTE_CLEARANCE` and `EDGE_TO_BUNDLE_CLEARANCE` were two independent `16.0` literals whose docstrings each claimed to be an alias of the other. `EDGE_TO_BUNDLE_CLEARANCE` now owns the value, and its docstring covers the external-route-channel constraint the other one described. `SECTION_ROUTE_CLEARANCE` stays as a real alias (`= EDGE_TO_BUNDLE_CLEARANCE`) because `layout/routing/inter_section_handlers.py` still spells it that way and that file is owned by another in-flight PR. `engine.py` and `routing/common.py` moved to the canonical name. Same float, so identical geometry.
- **`NF_METRO_ALLOW_BAD_CURVES`.** The bundle-curve guard downgraded its abort to a warning on either `graph.permissive` or this env var. The var appeared nowhere else in the repo (src, tests, docs, scripts, `.github`) and duplicated the documented `--permissive` flag. Only `graph.permissive` remains; the docstring mention and the now-unused `import os` go with it. This edits one boolean operand, not an arm count.
- **`compute_layout(row_gap=, section_gap=)`.** Neither parameter was read in the body and no caller in src, tests, scripts or docs passed either. Both are gone, along with the `ROW_GAP` / `SECTION_GAP` imports they were the only users of. `layout/route_reservations.py` has its own unrelated `CorridorRegionKind.ROW_GAP`, untouched.
- **Unreferenced names**, each verified to have zero references outside its own definition across `src/`, `tests/`, `scripts/`, `docs/` and `website/`: `render/icons.py::train_icon_path` (a placeholder diamond, absent from the module's `__all__`), `render/constants.py::LOGO_HEIGHT_DEFAULT`, `SECTION_NUM_CIRCLE_R`, `TRAIN_ICON_SIZE`, and `layout/constants.py::ENTRY_INSET_LR`. `SECTION_NUM_CIRCLE_R_LARGE` is live and stays; its docstring no longer distinguishes itself from a variant that does not exist.
- **Duplicate `_points_coincide`.** `layout/routing/convergences.py` defined its own copy with the same `COORD_TOLERANCE` semantics as the one in `layout/routing/common.py`. It imports the shared one now. `convergences.py` already imported from `common.py` and `common.py` does not import `convergences.py`, so there is no cycle.
- **`SettlementStage` reserved members.** `COHORT_INTENT`, `APERTURE_SETTLEMENT`, `FINAL_SOLVE` and `TYPED_MATERIALIZATION` are declared but never emitted; `tests/test_corridor_cohort_integration.py` asserts they never appear. The enum docstring now states which four stages a render does emit and that the rest are reserved.

## Verified

Run in the branch worktree with `PYTHONPATH` pointed at its `src/`, Python 3.11.14.

- `ruff check src/ tests/` - All checks passed
- `ruff format --check src/ tests/` - 405 files already formatted
- `mypy src/` - Success, no issues in 119 source files
- `pytest -q -rf tests/test_guard_registry_golden.py tests/test_routing_gate_coverage.py tests/test_corridor_cohort_integration.py tests/test_layout.py tests/test_cli.py tests/test_theme_mode.py` - **901 passed**, no skips (the gate-coverage test ran; it is not skipped on this interpreter). `git status` shows nothing under `tests/data/`: no guard golden or gate-coverage baseline was regenerated.
- `pytest -q -rf tests/test_topology_validation.py -x -k "rnaseq or variant"` - 24 passed, 1 xfailed
- Render corpus byte-diff: all 318 `examples/*.mmd` and `examples/topologies/*.mmd` rendered through `prepare_graph` + `render_graph` on this branch and on `origin/main`, MD5 joined on path. **318/318 identical, 0 render errors on either side.**

## Left in place

- `themes/nfcore.py::NFCORE_THEME = NFCORE_DARK_THEME` and `themes/seqera.py::SEQERA_THEME = SEQERA_DARK_THEME`. Both are exported from `themes/__init__.py` and are public API, so they stay even though the name does not say "dark". `NFCORE_THEME` has around 200 call sites across roughly 25 test modules; `SEQERA_THEME` has no consumer beyond its definition and the package export.
- `layout/constants.py::MIN_STRAIGHT_INTER` - referenced only from `tests/routing_inter_section.py` (two sites), never from `src/`. Its neighbours are not in the same position: `MIN_STRAIGHT_PORT` and `MIN_STRAIGHT_EDGE` are both used widely in `src/`.
- `SECTION_ROUTE_CLEARANCE` as an alias name, for the fenced `inter_section_handlers.py`.
- The unreachable dispatch arm in `layout/routing/inter_section_handlers.py`: removing it would require regenerating the gate-coverage baseline, which #1856 owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)