### PR TITLE
test: repoint stale xfails and remove dead scaffolding

### DIFF
--- a/tests/test_auto_layout.py
+++ b/tests/test_auto_layout.py
@@ -300,9 +300,10 @@ def test_explicit_grid_section_keeps_lr_against_auto_successor_below():
     successor lands in a lower grid row.
 
     Regression lock for #446: during auto-layout an explicit-grid section
-    still reads grid_col == -1, so comparing it against an auto neighbour
-    (row >= 0) used to fire the "all successors below" TB branch and reorient
-    the section vertically.
+    reads grid_col == -1, so a naive comparison against an auto neighbour
+    (row >= 0) reads every successor as below and takes the "all successors
+    below" TB branch.  Direction inference must not draw that conclusion from
+    a placeholder column.
     """
     graph = _make_graph_with_sections(
         ["manual", "downstream"],

--- a/tests/test_bare_render.py
+++ b/tests/test_bare_render.py
@@ -150,10 +150,3 @@ def test_bare_cli_flag(tmp_path):
     full_width = int(ET.parse(full_out).getroot().attrib["width"])
     bare_width = int(ET.parse(bare_out).getroot().attrib["width"])
     assert bare_width < full_width
-
-
-def test_bare_no_title_class_element():
-    """No SVG element with the nf-metro-title class is drawn in bare output."""
-    g = _graph(_TITLED_MMD)
-    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
-    assert _title_text_elements(bare_svg) == []

--- a/tests/test_bundle_order_invariant.py
+++ b/tests/test_bundle_order_invariant.py
@@ -42,11 +42,6 @@ FIXTURES = REPO_ROOT / "tests" / "fixtures"
 TOPOLOGIES = FIXTURES / "topologies"
 EXAMPLES = REPO_ROOT / "examples"
 
-# Fixtures with KNOWN bundle-order violations that the criterion
-# correctly surfaces.  These are real bugs we xfail rather than blunt
-# the criterion to hide them.
-_KNOWN_VIOLATION_FIXTURES: frozenset[str] = frozenset()
-
 
 # ---------------------------------------------------------------------------
 # Happy-path: every fixture and example must pass the invariant
@@ -72,17 +67,7 @@ def test_no_bundle_order_violations_in_gallery(path: Path) -> None:
     This is the corpus-level happy-path check.  A regression to a
     routing handler that creates a flipped concentric bundle would
     cause exactly one fixture to start failing here.
-
-    Fixtures listed in :data:`_KNOWN_VIOLATION_FIXTURES` are
-    xfailed: they have real bundle-order bugs at the Plots-entry
-    corner that the criterion correctly catches, and we'd rather
-    track those as known failures than silently blunt the criterion.
     """
-    if path.name in _KNOWN_VIOLATION_FIXTURES:
-        pytest.xfail(
-            f"{path.name} has a known bundle-order violation at the "
-            "Plots-entry corner; the criterion correctly catches it."
-        )
     graph = parse_metro_mermaid(path.read_text())
     compute_layout(graph)
     offsets = compute_station_offsets(graph)

--- a/tests/test_centered_tracks.py
+++ b/tests/test_centered_tracks.py
@@ -211,12 +211,12 @@ def _line_base_sign(graph, lid: str) -> float:
 def test_fork_weave_exclusive_runs_ride_their_line_rail():
     """A line's exclusive run must sit on its line's symmetric base rail.
 
-    The cross-line fork (top/mid/bot exclusive runs all diverging from the
-    same trunk station) used to be repacked into consecutive tracks by the
-    fork-equalize pass, collapsing the bottom line's run onto the trunk.
-    Each exclusive station must instead match its own line's base track, so
-    the top run rides above the trunk, the bottom run below, and the middle
-    run on the centre.
+    In a cross-line fork (top/mid/bot exclusive runs all diverging from the
+    same trunk station) the fork-equalize pass must not repack the runs into
+    consecutive tracks, which would collapse the bottom line's run onto the
+    trunk.  Each exclusive station matches its own line's base track, so the
+    top run rides above the trunk, the bottom run below, and the middle run
+    on the centre.
     """
     graph = _fork_weave_graph(centered=True)
     layers = assign_layers(graph)

--- a/tests/test_coincide_track_radii.py
+++ b/tests/test_coincide_track_radii.py
@@ -369,20 +369,9 @@ def test_leftward_up_channel_restack_preserves_concentric_radii() -> None:
     ]
 
 
-_XFAIL_COINCIDE_CENTRAL_DERIVATION: dict[str, str] = {}
-
-
-def _coincide_params() -> list:
-    params = []
-    for p in _gather_fixtures():
-        key = p.relative_to(REPO_ROOT).as_posix()
-        reason = _XFAIL_COINCIDE_CENTRAL_DERIVATION.get(key)
-        marks = (pytest.mark.xfail(reason=reason, strict=True),) if reason else ()
-        params.append(pytest.param(p, id=key, marks=marks))
-    return params
-
-
-@pytest.mark.parametrize("path", _coincide_params())
+@pytest.mark.parametrize(
+    "path", _gather_fixtures(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix()
+)
 def test_coincide_pass_corners_match_central_derivation(
     path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_fan_plans.py
+++ b/tests/test_fan_plans.py
@@ -2318,8 +2318,8 @@ def test_symmetric_style_keeps_planned_two_way_fan_on_shared_centreline() -> Non
             marks=pytest.mark.xfail(
                 strict=True,
                 reason=(
-                    "the column seats the stopping station on the fork's row and "
-                    "sends the passing line around it"
+                    "issue #1863: the column seats the stopping station on the "
+                    "fork's row and sends the passing line around it"
                 ),
             ),
         ),

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -2545,8 +2545,8 @@ def test_multi_path_gap_separates_by_b_and_centers():
     (A + w1 + B + w2 + A).
 
     03b_fan_in_merge's StepA|StepB gap carries a down-path (junction_7) and
-    an up-path (junction_6); they previously overlapped (~5px) and now
-    separate by B and straddle the gap centre.
+    an up-path (junction_6); the two must clear each other by B and straddle
+    the gap centre rather than overlapping.
     """
     from nf_metro.layout.constants import BUNDLE_TO_BUNDLE_CLEARANCE
     from nf_metro.layout.routing import route_edges

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1716,13 +1716,7 @@ def test_merge_fanout_shares_corner_by_construction(fixture, monkeypatch):
     assert not violations, "; ".join(v.message() for v in violations)
 
 
-_XFAIL_SYMFAN_PAIRS_SHARE_Y: dict[str, str] = {}
-
-
-@pytest.mark.parametrize(
-    "fixture",
-    _params_with_xfails(ALL_FIXTURES, _XFAIL_SYMFAN_PAIRS_SHARE_Y),
-)
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
 def test_symfan_pairs_share_y(fixture):
     """When a section has exactly two full-bundle stations in the same
     column (a classic symmetric-fan pair such as Reporting's Shiny app
@@ -5988,14 +5982,9 @@ def test_junction_same_line_fans_coincide_or_separate(fixture):
             )
 
 
-@pytest.mark.parametrize("fixture", sorted({*_FIXTURES_MULTI_SECTION_PLUS_STACK}))
-def test_inter_section_route_no_full_width_dogleg_clean(fixture):
-    """No merge feeder takes a full-width out-and-back dog-leg (#432).
-
-    The corridor route's long leftward traverse in the inter-row gap is a
-    monotonic approach toward the target, not a backtrack, so the refined
-    full-width guard passes on now.
-    """
+def _assert_no_backtrack_leg_over_40pc_of_canvas(fixture: str) -> None:
+    """Assert no inter-section route reverses in X for more than 40% of the
+    canvas width in a single leg."""
     from nf_metro.layout.engine import (
         _canvas_width,
         inter_section_route_backtrack_legs,
@@ -6013,6 +6002,17 @@ def test_inter_section_route_no_full_width_dogleg_clean(fixture):
             f"backtracks {span:.1f}px in one leg (x={x1:.1f}->{x2:.1f}), "
             f"exceeding 40% of canvas width {canvas_width:.1f}"
         )
+
+
+@pytest.mark.parametrize("fixture", sorted({*_FIXTURES_MULTI_SECTION_PLUS_STACK}))
+def test_inter_section_route_no_full_width_dogleg_clean(fixture):
+    """No merge feeder takes a full-width out-and-back dog-leg (#432).
+
+    A corridor route's long leftward traverse in the inter-row gap is a
+    monotonic approach toward its target rather than a backtrack, so it must
+    not count against the full-width guard.
+    """
+    _assert_no_backtrack_leg_over_40pc_of_canvas(fixture)
 
 
 @pytest.mark.parametrize("fixture", _FIXTURES_DOGLEG)
@@ -6028,23 +6028,7 @@ def test_inter_section_route_no_full_width_dogleg(fixture):
     bounds those reversals: a right-then-left dog-leg sweeping the whole
     diagram is forbidden even when exempt.
     """
-    from nf_metro.layout.engine import (
-        _canvas_width,
-        inter_section_route_backtrack_legs,
-    )
-
-    graph = _layout(fixture)
-    routes = route_edges(graph)
-    canvas_width = _canvas_width(graph)
-    assert canvas_width > 0
-    limit = 0.4 * canvas_width
-    for rp, x1, x2 in inter_section_route_backtrack_legs(graph, routes):
-        span = abs(x2 - x1)
-        assert span <= limit + _Y_TOL, (
-            f"{fixture}: {rp.line_id} {rp.edge.source}->{rp.edge.target} "
-            f"backtracks {span:.1f}px in one leg (x={x1:.1f}->{x2:.1f}), "
-            f"exceeding 40% of canvas width {canvas_width:.1f}"
-        )
+    _assert_no_backtrack_leg_over_40pc_of_canvas(fixture)
 
 
 # ---------------------------------------------------------------------------
@@ -8047,14 +8031,10 @@ def test_section_bbox_has_bottom_padding(fixture):
 # A section that fans a branch above its trunk gets a full top padding band
 # restored by ``_reserve_row_gap_for_top_padding`` + ``_fit_bboxes_to_content_top``:
 # when a same-column section directly above would clamp the grow, the lower row is
-# pushed down to make room.  No fixture is expected to fall short.
-_XFAIL_BBOX_TOP_PAD: dict[str, str] = {}
+# pushed down to make room.
 
 
-@pytest.mark.parametrize(
-    "fixture",
-    _params_with_xfails(ALL_FIXTURES, _XFAIL_BBOX_TOP_PAD),
-)
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
 def test_section_bbox_has_top_padding(fixture):
     """Each section's bbox top must sit at least ``section_y_padding``
     above the centre Y of its highest internal station.
@@ -8105,9 +8085,7 @@ def test_section_bbox_has_top_padding(fixture):
     )
 
 
-@pytest.mark.parametrize(
-    "fixture", _params_with_xfails(ALL_FIXTURES, _XFAIL_BBOX_TOP_PAD)
-)
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
 def test_section_bbox_padding_clears_symmetric_fan_bundle_span(fixture):
     """A symmetric diamond's off-trunk branches must get equal, full padding.
 
@@ -9151,7 +9129,7 @@ def test_station_x_within_column_tolerance(fixture):
 # ---------------------------------------------------------------------------
 
 _SV_STATS_NUDGE_REASON = (
-    "issue #348: sv_stats label nudged 14.1px to clear bcftools_stats "
+    "issue #1863: sv_stats label nudged 14.1px to clear bcftools_stats "
     "label collision; revisit when the engine collision-clearance is "
     "tuned or the section is restructured"
 )
@@ -9159,25 +9137,25 @@ _XFAIL_LABEL_AT_STATION_X: dict[str, str] = {
     "variantbenchmarking.mmd": _SV_STATS_NUDGE_REASON,
     "variantbenchmarking_auto.mmd": _SV_STATS_NUDGE_REASON,
     "topologies/foldback_exit_peeloff.mmd": (
-        "issue #348: samtools_stats label nudged 17.1px to clear an adjacent "
+        "issue #1863: samtools_stats label nudged 17.1px to clear an adjacent "
         "label collision in the dense GATK Preprocessing section (forward top "
         "row, unrelated to the return-row peel-off this fixture locks); revisit "
         "when the engine collision-clearance is tuned"
     ),
     "topologies/manual_rl_row_nonconsumer_bypass.mmd": (
-        "issue #348: samtools_stats label nudged 17.1px to clear an adjacent "
+        "issue #1863: samtools_stats label nudged 17.1px to clear an adjacent "
         "label collision in the dense GATK Preprocessing section (forward top "
         "row, unrelated to the manual RL-row bypass this fixture locks); revisit "
         "when the engine collision-clearance is tuned"
     ),
     "topologies/packed_cell_cellmate_bypass.mmd": (
-        "issue #348: samtools_stats label nudged 17.1px to clear an adjacent "
+        "issue #1863: samtools_stats label nudged 17.1px to clear an adjacent "
         "label collision in the dense GATK Preprocessing section (forward top "
         "row, unrelated to the packed-cell bypass this fixture locks); revisit "
         "when the engine collision-clearance is tuned"
     ),
     "topologies/packed_cell_cellmate_bypass_adjacent.mmd": (
-        "issue #348: samtools_stats label nudged 17.1px to clear an adjacent "
+        "issue #1863: samtools_stats label nudged 17.1px to clear an adjacent "
         "label collision in the dense GATK Preprocessing section (forward top "
         "row, unrelated to the packed-cell bypass this fixture locks); revisit "
         "when the engine collision-clearance is tuned"

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -188,11 +188,11 @@ def test_marker_station_renders_valid_svg():
 
 
 def test_no_marker_directives_byte_identical():
-    # A diagram with no marker directives must render exactly as before the
-    # feature: markers default-off.
+    # Markers are default-off: a diagram that declares none must render
+    # byte-identically to one whose declared marker was cleared.
     g_plain = _parse()
     g_with = _parse("%%metro marker: n2 | square, solid\n")
-    # Remove the marker so the only difference is the (now-cleared) directive.
+    # Clear the marker so the parsed directive is the only difference left.
     g_with.stations["n2"].marker = None
     compute_layout(g_plain)
     compute_layout(g_with)

--- a/tests/test_process_directive.py
+++ b/tests/test_process_directive.py
@@ -167,10 +167,10 @@ def test_process_scope_absent_keeps_regex_semantics():
 def test_process_directive_does_not_change_visual_render():
     """The directive must not perturb layout or the drawn SVG output.
 
-    It is no longer pure metadata at the byte level: the mapping is now
-    serialized into the embedded ``<metadata>`` manifest (so a committed SVG
-    carries it). But everything *drawn* must be byte-identical -- the directive
-    still never moves a station or changes a glyph.
+    It is not pure metadata at the byte level: the mapping is serialized into
+    the embedded ``<metadata>`` manifest, so a committed SVG carries it. But
+    everything *drawn* must be byte-identical -- the directive never moves a
+    station or changes a glyph.
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -152,41 +152,6 @@ def test_stacked_sections_serpentine_no_backtrack(path):
     assert not errors, "\n".join(v.message for v in errors)
 
 
-# --- Layout-quality warning reporter ---
-#
-# The intra-section-chain and exit-port-feeder validators emit WARNING-level
-# violations because legitimate fork-join layouts also produce them. Tests
-# above gate CI on ERRORs only. This block prints the warning count per
-# fixture so CI logs surface candidates for layout improvement without
-# failing the build.
-
-
-def _layout_quality_warning_count(graph) -> tuple[int, int, int]:
-    chain = check_intra_section_chain_alignment(graph)
-    port = check_exit_port_feeder_alignment(graph)
-    diag = check_single_segment_diagonals(graph)
-    return (
-        sum(1 for v in chain if v.severity == Severity.WARNING),
-        sum(1 for v in port if v.severity == Severity.WARNING),
-        sum(1 for v in diag if v.severity == Severity.WARNING),
-    )
-
-
-@pytest.mark.parametrize("path", TOPOLOGY_FILES, ids=TOPOLOGY_IDS)
-def test_layout_quality_warnings_report(path, capsys):
-    """Report warning counts for each topology - never fails."""
-    graph = _load_and_layout(path)
-    chain_warns, port_warns, diag_warns = _layout_quality_warning_count(graph)
-    if chain_warns or port_warns or diag_warns:
-        with capsys.disabled():
-            print(
-                f"\n  {path.stem}: "
-                f"intra_section_chain_alignment={chain_warns}, "
-                f"exit_port_feeder_alignment={port_warns}, "
-                f"single_segment_diagonals={diag_warns}"
-            )
-
-
 # --- Regression guard: funcprofiler_upstream reporting line ---
 #
 # funcprofiler_upstream is a real upstream pipeline (11 lines, 7 parallel
@@ -256,41 +221,35 @@ class TestExitRunThreeDropColumnsMergeFeeder:
         assert not violations, "\n".join(v.message for v in violations)
 
 
-# --- Failing regression: variant_calling ---
+# --- variant_calling layout guards ---
 #
-# variant_calling.mmd had three confirmed visible defects (verified
-# manually with the user as part of validator development):
+# variant_calling.mmd pins three layout properties confirmed by eye with the
+# user during validator development:
 #
-# 1. Section 2 (Alignment) chain alignment - bwa_index, bwa_mem,
-#    samtools_sort, samtools_index alternated rows in a 4-station zigzag
-#    on the Main line. FIXED in #420: bwa_mem is a fan-in (the bwa_index
-#    branch plus the fastp entry both carry Main into it), so the entry
-#    phantom now anchors the through-trunk while bwa_index fans in above
+# 1. Section 2 (Alignment) chain alignment - bwa_mem is a fan-in (the
+#    bwa_index branch and the fastp entry both carry Main into it), so the
+#    entry phantom anchors the through-trunk while bwa_index fans in above
 #    it, keeping bwa_mem -> samtools_sort -> samtools_index straight.
-# 2. Section 3 (Variant Calling) excessive column gap - GATK
-#    HaplotypeCaller and DeepVariant share column x=772 but are 80px
-#    apart with one empty grid row between them. STILL OPEN (#453).
-# 3. Section 1 -> Section 2/4 inter-section line crossing - Main and
-#    QC Reporting both fanned out from junction __junction_6 and crossed
-#    on the way to their respective targets. FIXED as a side effect of
-#    #420 (the straight Alignment trunk removes the crossing).
-#
-# Defects 1 and 3 now pass; defect 2 remains xfail until the column-gap
-# layout is fixed.
+# 2. Section 3 (Variant Calling) column gaps - GATK HaplotypeCaller and
+#    DeepVariant share column x=772 but sit 80px apart with one empty grid
+#    row between them.  A live defect, held below as a strict xfail.
+# 3. Section 1 -> Section 2/4 inter-section crossings - Main and QC
+#    Reporting both fan out from junction __junction_6, and the straight
+#    Alignment trunk keeps them from crossing en route to their targets.
 
 VARIANT_CALLING_FILE = EXAMPLES_DIR / "variant_calling.mmd"
 
 
 _VARIANT_CALLING_XFAIL = pytest.mark.xfail(
     strict=True,
-    reason="known variant_calling layout defect; tracked in #453",
+    reason="known variant_calling layout defect; tracked in #1863",
 )
 
 
 class TestVariantCallingDefects:
     """Lock in known variant_calling layout defects via strict xfail.
 
-    Each remaining defect is currently present; when an engine fix lands
+    Each defect held here is currently present; when an engine fix lands
     the matching xfail flips to XPASS and reds CI, prompting the marker
     removal.
     """


### PR DESCRIPTION
Test-suite hygiene ahead of the release. Tests only; nothing under `src/`, `docs/`, `examples/` or `scripts/` is touched.

## Repointed strict xfails

Every `xfail(strict=True)` in the suite whose reason cited a closed issue now cites #1863, filed as the live tracker for the three defect families they lock in. The technical part of each reason is unchanged.

- `tests/test_topology_validation.py` `TestVariantCallingDefects::test_no_excessive_column_gaps` cited #453 (closed 2026-06-03).
- `tests/test_layout_invariants.py` `_XFAIL_LABEL_AT_STATION_X`, six entries against `test_label_x_anchored_to_station_marker_on_horizontal_runs`, all citing #348 (closed 2026-05-17). The section header keeps its `#348` provenance note, matching its sibling at `test_visual_stack_station_xs_share_column`.
- `tests/test_fan_plans.py` the `bypass_v_tight.mmd` param of `test_a_bypass_helper_keeps_the_row_the_line_it_carries_runs_on` carried no issue reference at all. It describes a defect rather than a design exclusion (its three sibling `bypass_label_rake*` fixtures pass), so it is now tracked and cited.

No open issue already covered these; searches on `xfail`, `variant_calling`, `column gap`, `label collision clearance`, `label nudge` and `bypass_v_tight` turned up nothing that fits.

## Removed dead scaffolding

Collected parametrisation ids are byte-identical to `main` at all four sites (verified by diffing `--collect-only` output).

- `tests/test_bundle_order_invariant.py`: `_KNOWN_VIOLATION_FIXTURES` was an empty frozenset, so its `pytest.xfail()` branch was unreachable. Removed along with the docstring paragraph describing xfails that do not exist.
- `tests/test_coincide_track_radii.py`: `_XFAIL_COINCIDE_CENTRAL_DERIVATION` was empty, so `_coincide_params()` reduced to setting ids. Replaced with an `ids=` lambda on the parametrize.
- `tests/test_layout_invariants.py`: `_XFAIL_SYMFAN_PAIRS_SHARE_Y` and `_XFAIL_BBOX_TOP_PAD` were empty, so `_params_with_xfails(ALL_FIXTURES, {})` returned plain params. Both call sites now parametrise over `ALL_FIXTURES` directly. `_params_with_xfails` itself stays, still used by the label-X site.

## Removed tests

- `tests/test_topology_validation.py::test_layout_quality_warnings_report` laid out all 284 topology fixtures only to print warning counts, with a docstring saying it never fails. Nothing but a stale `.test_durations` entry referenced it. Its `_layout_quality_warning_count` helper went with it; every validator it imported is still used elsewhere in the module.
- `tests/test_bare_render.py::test_bare_no_title_class_element` was byte-identical to `test_bare_omits_title` above it. Kept the earlier one, whose name reads better.

## Rewritten history-narrating comments

Each now states what the test asserts and why, with no reference to past behaviour.

- `tests/test_topology_validation.py`: the 16-line variant_calling block ("FIXED in #420", "STILL OPEN (#453)", "Defects 1 and 3 now pass") now describes the three properties the fixture pins. The class docstring's "Each remaining defect" is likewise now self-contained.
- `tests/test_layout.py`: "they previously overlapped (~5px) and now separate".
- `tests/test_auto_layout.py`: "used to fire the TB branch".
- `tests/test_centered_tracks.py`: "used to be repacked".
- `tests/test_markers.py`: "exactly as before the feature", plus the "(now-cleared)" aside.
- `tests/test_process_directive.py`: "It is no longer pure metadata... is now serialized".
- `tests/test_layout_invariants.py`: "so the refined full-width guard passes on now".

## Deduplication

`test_inter_section_route_no_full_width_dogleg_clean` and `test_inter_section_route_no_full_width_dogleg` had identical bodies and differ only in fixture set and rationale. Both now call `_assert_no_backtrack_leg_over_40pc_of_canvas`, keeping their distinct docstrings.

## Tracking issue

#1863

## Verified

Env `nf-metro`, `PYTHONPATH` at the worktree `src/`.

- `ruff check tests/` and `ruff format --check tests/`: clean, 286 files already formatted.
- `pytest -q -rf` over the ten touched modules (`test_topology_validation`, `test_bare_render`, `test_bundle_order_invariant`, `test_coincide_track_radii`, `test_layout`, `test_auto_layout`, `test_centered_tracks`, `test_markers`, `test_process_directive`, `test_fan_plans`): 3050 passed, 2 xfailed.
- `pytest -q -rf tests/test_layout_invariants.py` in full: 25268 passed, 68 skipped, 6 xfailed, 2m05s.
- `--collect-only` ids diffed against `main` for the four de-scaffolded parametrize sites: identical.
- `git status` clean under `tests/data/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)