### PR TITLE
docs(topologies): catalogue every fixture in the README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Any env with the project importable and `cairosvg` available works. Prefer point
 
 - Test fixtures: `tests/fixtures/`
 - Example pipelines: `examples/` (including `rnaseq_sections.mmd` with manual grid and `rnaseq_auto.mmd` with fully inferred layout)
-- Topology stress tests: `examples/topologies/*.mmd` - 284 fixtures covering fan-out, fan-in, diamonds, folds, mixed port sides, etc. See `examples/topologies/README.md` for the structural-class index and known issues; it catalogues 153 of them, so roughly half the corpus is uncatalogued. The test sweep globs the directory rather than reading the README, so an uncatalogued fixture is still exercised by every validator check - adding one changes the invariant suite, and the full suite must be run.
+- Topology stress tests: `examples/topologies/*.mmd` - 284 fixtures covering fan-out, fan-in, diamonds, folds, mixed port sides, etc. See `examples/topologies/README.md` for the structural-class index and known issues; it catalogues all of them, and `scripts/list_topology_fixtures.py` reports any fixture missing from it. The test sweep globs the directory rather than reading the README, so a fixture is exercised by every validator check whether or not it is catalogued - adding one changes the invariant suite, and the full suite must be run.
 - `tests/layout_validator.py` - Programmatic layout checks (section overlap, station containment, port positioning, edge waypoints).
 - `tests/test_topology_validation.py` - Parametrized tests running all validator checks against every topology fixture.
 - `scripts/render_topologies.py` - Batch render all fixtures to `/tmp/nf_metro_topology_renders/`.

--- a/examples/topologies/README.md
+++ b/examples/topologies/README.md
@@ -2,17 +2,26 @@
 
 Example `.mmd` files demonstrating a range of pipeline topologies and the layout patterns they produce. Each example exercises different aspects of the auto-layout engine.
 
-To render all examples:
+This directory holds 284 fixtures and every one of them is named in this file: the illustrated ones in the walkthrough sections below, the rest in the [Regression Catalogue](#regression-catalogue).
+
+To render one example:
 
 ```bash
 nf-metro render examples/topologies/wide_fan_out.mmd -o /tmp/wide_fan_out.svg
 ```
 
+The sweep tests glob this whole directory, so a fixture is exercised whether or
+not it is catalogued here: `tests/test_topology_validation.py` runs every
+validator check against every `.mmd`, and `tests/test_layout_invariants.py`
+sweeps the same set. `python scripts/list_topology_fixtures.py` prints the
+fixtures on disk with their `%%metro title:` and names any that this file has
+missed.
+
 ---
 
 ## Structural class index
 
-Each fixture is tagged with the layout class(es) it primarily exercises. Use this table to find a fixture that stresses a specific engine subsystem.
+The fixtures below are tagged with the layout class(es) they primarily exercise. Use this table to find one that stresses a specific engine subsystem; the remaining fixtures are grouped by theme in the [Regression Catalogue](#regression-catalogue).
 
 | Fixture                                      | Structural class(es)                                                                                                                                                                                                            |
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -325,13 +334,15 @@ A single-row long-read variant-calling map. The annotation section carries only 
 
 ## Regression Catalogue
 
-The fixtures below are targeted regression guards: each was added to pin a
+The 207 fixtures below are targeted regression guards: each was added to pin a
 specific routing or layout fix and is not individually gallery-illustrated.
 They participate in the full topology validation suite (`pytest
-tests/test_topology_validation.py`) alongside the documented fixtures
+tests/test_topology_validation.py`) alongside the illustrated fixtures
 above.
 
-To regenerate this catalogue from disk:
+Entries are grouped by the theme each guard belongs to; a fixture that carries
+an issue number in its own header or in the commit that added it cites that
+number here. To check the catalogue against disk:
 
 ```bash
 python scripts/list_topology_fixtures.py
@@ -347,6 +358,12 @@ python scripts/list_topology_fixtures.py
 | `bypass_label_rake_left.mmd`         | Bypass V climbing past a wide station label on the left side - extends `bypass_label_rake` for the left-overrun direction                                                                                                                                                                        |
 | `bypass_label_rake_wide.mmd`         | Bypass V past an extra-wide label - tests the rake shift under maximal label width                                                                                                                                                                                                               |
 | `bypass_v_tight.mmd`                 | Two-line bypass V with minimal x-spacing - tests bypass geometry under the tightest legal x-spacing                                                                                                                                                                                              |
+| `bypass_leftward_overflow.mmd`       | Seven-line reverse-flow bypass through a middle section - the overflowing bundle is ordered by trunk direction (#723)                                                                                                                                                                            |
+| `bypass_left_entry_from_right.mmd`   | A junction bypass reaching a far LEFT entry on an RL target from the right, past an intervening section and a sibling                                                                                                                                                                            |
+| `fan_bypass_shared_band.mmd`         | Two legs of one junction fan sharing a single bypass band past stacked intervening sections                                                                                                                                                                                                      |
+| `inrow_skip_breeze.mmd`              | Two-line express skip inside one section - the skipping line bows around the station it does not consume (#990, #999)                                                                                                                                                                            |
+| `sectionless_skip_breeze.mmd`        | The same express skip on sectionless nodes - the skip line detours around non-consumer markers                                                                                                                                                                                                   |
+| `multirow_source_stacked_fan.mmd`    | A four-line source spanning two rows feeding a stacked fan - the steep multi-line bypass bundle keeps distinct slots (#1457)                                                                                                                                                                     |
 
 ### Compact layout / gap heuristics
 
@@ -360,17 +377,29 @@ python scripts/list_topology_fixtures.py
 
 ### Cross-column perpendicular drop / perp entry
 
-| Fixture                                     | What it tests                                                                                                                                                                                                                                 |
-| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cross_col_top_entry.mmd`                   | Cross-column top entry - an LR section's TOP-entry port receiving from a horizontally-offset source; tests the dead-room removal fix (#890)                                                                                                   |
-| `cross_column_perp_drop.mmd`                | Cross-column perpendicular drop - a line dropping from an LR section into a section below and to one side (#879)                                                                                                                              |
-| `cross_column_perp_drop_far_exit.mmd`       | Cross-column perp drop with a far-side exit - the source exits from the far face, requiring the lead-in to span only the source column (#892)                                                                                                 |
-| `lr_perp_bottom_exit_perp_entry.mmd`        | LR section exiting via a BOTTOM port into a BOTTOM-entry section below - tests the perpendicular-to-perpendicular drop path                                                                                                                   |
-| `lr_perp_bottom_exit_side_entry.mmd`        | LR section BOTTOM exit into a side-entry section below - tests the BOTTOM-exit / side-entry routing arm                                                                                                                                       |
-| `lr_perp_top_exit_perp_entry.mmd`           | LR section TOP exit into a TOP-entry section above - tests the perpendicular-to-perpendicular upward drop                                                                                                                                     |
-| `lr_perp_top_exit_perp_entry_diverging.mmd` | LR section TOP exit into a diverging TOP-entry target - tests the same path with multiple lines diverging at the entry port                                                                                                                   |
-| `lr_perp_top_exit_side_entry.mmd`           | LR section TOP exit into a side-entry section - tests the TOP-exit / side-entry routing arm                                                                                                                                                   |
-| `top_entry_bundle_offset_seam.mmd`          | A line splitting off a shared trunk drops into an LR/RL TOP-entry port carrying a within-bundle offset - tests that the single-line descent lands on the port-crossing X so it meets the intra-section drop without a boundary jitter (#1302) |
+| Fixture                                                | What it tests                                                                                                                                                                                                                                 |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cross_col_top_entry.mmd`                              | Cross-column top entry - an LR section's TOP-entry port receiving from a horizontally-offset source; tests the dead-room removal fix (#890)                                                                                                   |
+| `cross_column_perp_drop.mmd`                           | Cross-column perpendicular drop - a line dropping from an LR section into a section below and to one side (#879)                                                                                                                              |
+| `cross_column_perp_drop_far_exit.mmd`                  | Cross-column perp drop with a far-side exit - the source exits from the far face, requiring the lead-in to span only the source column (#892)                                                                                                 |
+| `lr_perp_bottom_exit_perp_entry.mmd`                   | LR section exiting via a BOTTOM port into a BOTTOM-entry section below - tests the perpendicular-to-perpendicular drop path                                                                                                                   |
+| `lr_perp_bottom_exit_side_entry.mmd`                   | LR section BOTTOM exit into a side-entry section below - tests the BOTTOM-exit / side-entry routing arm                                                                                                                                       |
+| `lr_perp_top_exit_perp_entry.mmd`                      | LR section TOP exit into a TOP-entry section above - tests the perpendicular-to-perpendicular upward drop                                                                                                                                     |
+| `lr_perp_top_exit_perp_entry_diverging.mmd`            | LR section TOP exit into a diverging TOP-entry target - tests the same path with multiple lines diverging at the entry port                                                                                                                   |
+| `lr_perp_top_exit_side_entry.mmd`                      | LR section TOP exit into a side-entry section - tests the TOP-exit / side-entry routing arm                                                                                                                                                   |
+| `top_entry_bundle_offset_seam.mmd`                     | A line splitting off a shared trunk drops into an LR/RL TOP-entry port carrying a within-bundle offset - tests that the single-line descent lands on the port-crossing X so it meets the intra-section drop without a boundary jitter (#1302) |
+| `lr_perp_top_entry_bottom_exit.mmd`                    | One LR section with a TOP entry and a BOTTOM exit - the bbox, exit port and lane order are carried through the perpendicular pair                                                                                                             |
+| `lr_perpendicular_ports_overflow.mmd`                  | An LR annotation section with both ports forced perpendicular, between LR neighbours                                                                                                                                                          |
+| `lr_top_entry_bundle_east_turn.mmd`                    | Two-line straight-drop TOP-entry seam whose bundle turns east on arrival - the seam nests against the turns either side of it                                                                                                                 |
+| `lr_top_entry_cross_column.mmd`                        | A TB section dropping into an LR TOP entry one column across - the LR bbox grows for the cross-column perpendicular entry (#1057)                                                                                                             |
+| `lr_top_entry_cross_column_two_line.mmd`               | Two-line member of the same cross-column drop - the perpendicular-entry corner nests by arrival order for right-turning runs                                                                                                                  |
+| `rl_bottom_exit_lr_top_entry_bundle.mmd`               | An RL section's BOTTOM exit feeding an LR TOP entry, the bundle turning east at the seam                                                                                                                                                      |
+| `lr_bottom_exit_rl_top_entry_jog.mmd`                  | Six-section map whose LR BOTTOM exit drops into stacked RL TOP entries - the perpendicular drops co-align rather than jogging                                                                                                                 |
+| `bottom_exit_junction_collinear_top_entry.mmd`         | A junction-fed BOTTOM exit dropping collinearly into a TOP entry directly below (#1428, #1509)                                                                                                                                                |
+| `bottom_exit_junction_offset_target.mmd`               | The same bottom-exit junction feed with the target offset, so the drop detours around an intervening section (#1428)                                                                                                                          |
+| `bottom_exit_stacked_right_entry_multiline_branch.mmd` | Multi-line branch member of the bottom-exit stacked RIGHT-entry fan - stacked fan grid origins are normalised                                                                                                                                 |
+| `bottom_entry_same_row_boundary.mmd`                   | A section whose BOTTOM entry carries both lines from a same-row source to its left, exercising the BOTTOM-entry L-shape rule                                                                                                                  |
+| `entry_hint_shared_edge.mmd`                           | The same section with `entry: bottom` hinted for only one of the two lines on the shared edge, so conflicting hints collapse to one hinted side                                                                                               |
 
 ### LR-to-TB top-entry routing
 
@@ -393,12 +422,13 @@ python scripts/list_topology_fixtures.py
 
 ### Section-header placement
 
-| Fixture                          | What it tests                                                                                                                                  |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `header_nudge.mmd`               | Header nudged past a trunk route - tests the nudge-right fallback when the default above-section placement clashes with a route (#774)         |
-| `header_side_rotated.mmd`        | Header rotated to a side face - tests the rotated-side placement arm of the header-placement chain (#774)                                      |
-| `top_entry_header_clash.mmd`     | TOP-entry route clips the section header in its default position - tests that header placement relocates the badge clear of the incoming route |
-| `narrow_section_header_wrap.mmd` | A section title wider than its narrow box - tests that the header wraps onto extra lines instead of overhanging the box (#1310)                |
+| Fixture                            | What it tests                                                                                                                                               |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `header_nudge.mmd`                 | Header nudged past a trunk route - tests the nudge-right fallback when the default above-section placement clashes with a route (#774)                      |
+| `header_side_rotated.mmd`          | Header rotated to a side face - tests the rotated-side placement arm of the header-placement chain (#774)                                                   |
+| `top_entry_header_clash.mmd`       | TOP-entry route clips the section header in its default position - tests that header placement relocates the badge clear of the incoming route              |
+| `narrow_section_header_wrap.mmd`   | A section title wider than its narrow box - tests that the header wraps onto extra lines instead of overhanging the box (#1310)                             |
+| `crowded_header_nudge_overtop.mmd` | A long section title between two TB neighbours leaves no room for the default badge placement - the crowded nudge aborted the render before the fix (#1308) |
 
 ### Junction entry
 
@@ -413,59 +443,204 @@ python scripts/list_topology_fixtures.py
 
 ### Left- and right-entry routing
 
-| Fixture                               | What it tests                                                                                                                                            |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `around_below_ep_col_gt0.mmd`         | Around-below routing when the entry point's column is > 0 - extends `around_section_below` to non-zero column positions                                  |
-| `bottom_row_climb_clear_corridor.mmd` | Bottom-row section receiving a line that must climb over a clear corridor - tests the corridor-clear climb path                                          |
-| `left_entry_up_wrap.mmd`              | Left-entry bundle arriving via an upward wrap (source is below-right) - tests that bundle order is preserved through the up-then-left wrap corner (#758) |
-| `right_entry_from_above.mmd`          | RIGHT-entry section fed from a section in the row above - tests the drop-in path (#889)                                                                  |
-| `right_entry_from_above_far.mmd`      | RIGHT-entry from above with the source far to the right - tests the drop-in path when the source is beyond the target's right edge (#889)                |
-| `right_entry_gap_above_empty_row.mmd` | RIGHT-entry with an empty row above the target - tests that the gap-above fallback fires when the drop-in is blocked by an empty row                     |
-| `right_entry_wrap_no_fan.mmd`         | RIGHT-entry wrap with a single line (no fan) - tests the wrap path without fan geometry                                                                  |
-| `right_entry_wrap_bundle.mmd`         | The two-line member of that wrap - the half-turn re-nests the bundle, so the lines stay nested rather than swapping at the port (#1767)                  |
-| `rl_entry_runway.mmd`                 | RL-section entry runway - a section in RL direction requiring an extended approach runway; tests runway-length calculation                               |
-| `stacked_left_exit_drop.mmd`          | Stacked sections sharing a LEFT exit drop - tests that multiple stacked sections can share the same exit drop column without overlap                     |
-| `stacked_split_right_entry_drop.mmd`  | RIGHT-facing mirror of the stacked split drop - the half-turn mirrors the bundle, so the split consumer's branch tracks mirror with it (#1767)           |
+| Fixture                                  | What it tests                                                                                                                                            |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `around_below_ep_col_gt0.mmd`            | Around-below routing when the entry point's column is > 0 - extends `around_section_below` to non-zero column positions                                  |
+| `bottom_row_climb_clear_corridor.mmd`    | Bottom-row section receiving a line that must climb over a clear corridor - tests the corridor-clear climb path                                          |
+| `left_entry_up_wrap.mmd`                 | Left-entry bundle arriving via an upward wrap (source is below-right) - tests that bundle order is preserved through the up-then-left wrap corner (#758) |
+| `right_entry_from_above.mmd`             | RIGHT-entry section fed from a section in the row above - tests the drop-in path (#889)                                                                  |
+| `right_entry_from_above_far.mmd`         | RIGHT-entry from above with the source far to the right - tests the drop-in path when the source is beyond the target's right edge (#889)                |
+| `right_entry_gap_above_empty_row.mmd`    | RIGHT-entry with an empty row above the target - tests that the gap-above fallback fires when the drop-in is blocked by an empty row                     |
+| `right_entry_wrap_no_fan.mmd`            | RIGHT-entry wrap with a single line (no fan) - tests the wrap path without fan geometry                                                                  |
+| `right_entry_wrap_bundle.mmd`            | The two-line member of that wrap - the half-turn re-nests the bundle, so the lines stay nested rather than swapping at the port (#1767)                  |
+| `rl_entry_runway.mmd`                    | RL-section entry runway - a section in RL direction requiring an extended approach runway; tests runway-length calculation                               |
+| `stacked_left_exit_drop.mmd`             | Stacked sections sharing a LEFT exit drop - tests that multiple stacked sections can share the same exit drop column without overlap                     |
+| `stacked_split_right_entry_drop.mmd`     | RIGHT-facing mirror of the stacked split drop - the half-turn mirrors the bundle, so the split consumer's branch tracks mirror with it (#1767)           |
+| `left_entry_from_above_far.mmd`          | LEFT entry fed by a far drop from a source two columns back in the row above                                                                             |
+| `right_entry_over_top_tall_upstream.mmd` | RIGHT entry reached over the top of a tall upstream section - the over-top channel drops below the section it crosses (#1364)                            |
+| `samerow_left_exit_far_left_entry.mmd`   | Same-row LEFT exit into a far LEFT entry - the route runs over the target's top rather than below it (#1397)                                             |
+| `route_around_to_top_entry.mmd`          | A feeder in the row below wrapping around its target into the target's TOP entry (#1522)                                                                 |
+| `route_around_far_column_top_entry.mmd`  | The same wrap where the target is the rightmost section in its row, so the route rounds the far column (#1522)                                           |
+| `top_entry_left_neighbour.mmd`           | TOP entry fed from the section immediately to its left, with an off-track reference input on the consumer                                                |
+| `stacked_multiline_left_exit_drop.mmd`   | Two-line member of the stacked LEFT-exit drop into an RL target                                                                                          |
+| `stacked_split_left_entry_drop.mmd`      | LEFT-facing member of the stacked split drop pair, mirroring `stacked_split_right_entry_drop`                                                            |
+| `stacked_right_ports_coincident.mmd`     | A feeder's RIGHT exit and an RL section's RIGHT entry at the same X - the connector bows out instead of drawing a bare vertical                          |
+| `rl_entry_right_exit_left.mmd`           | A reversed section entered on its RIGHT and left on its LEFT - re-orientation keeps the exit port on the shifted boundary (#1298, #1300)                 |
 
 ### Merge / reconvergence routing
 
-| Fixture                                | What it tests                                                                                                                              |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `exit_lane_rise_bundle_order.mmd`      | Exit port a lane above its own trunk - the climb out keeps the order the converging entry fixed, rather than crossing the pair (#1770)     |
-| `merge_around_below_leftmost.mmd`      | Merge where the continuation must route around a section sitting below and to the left of the leftmost source                              |
-| `merge_bottom_row_bypass.mmd`          | Merge on the bottom row where one branch arrives via an inter-row bypass                                                                   |
-| `merge_leftmost_sink_branch.mmd`       | Merge where the sink section is the leftmost section in its row - tests that the merge trunk does not overshoot left                       |
-| `merge_offrow_continuation.mmd`        | Merge continuation that lands off the trunk row - tests that the continuation trunk is re-anchored to the correct row                      |
-| `merge_port_above_approach.mmd`        | Merge port approached from above - tests the above-approach routing arm for a merge entry                                                  |
-| `merge_pullaway.mmd`                   | Merge trunk pull-away across a cross-row sibling - tests that the trunk stays clear of the sibling section's bounding box                  |
-| `merge_right_entry.mmd`                | Merge feeder arriving via a cross-row RIGHT entry - tests the interaction of RIGHT-entry routing with merge-trunk continuation             |
-| `merge_trunk_out_of_range_section.mmd` | Merge trunk passing over a section outside its x-range - tests that the trunk does not clip sections it should not cross                   |
-| `merge_trunk_over_low_section.mmd`     | Merge trunk passing over a lower section - tests clear-corridor routing for trunks that cross over shorter sections                        |
-| `post_convergence_trunk.mmd`           | Trunk continuation after a convergence fold - tests that the post-convergence section inherits the correct trunk row and bundle offsets    |
-| `reconverge_reversed_fold.mmd`         | Reconvergence from a reversed fold (#705) - tests that the back-run after a reversed fold stays level and the fan/merge order is preserved |
+| Fixture                                | What it tests                                                                                                                                 |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `exit_lane_rise_bundle_order.mmd`      | Exit port a lane above its own trunk - the climb out keeps the order the converging entry fixed, rather than crossing the pair (#1770)        |
+| `merge_around_below_leftmost.mmd`      | Merge where the continuation must route around a section sitting below and to the left of the leftmost source                                 |
+| `merge_bottom_row_bypass.mmd`          | Merge on the bottom row where one branch arrives via an inter-row bypass                                                                      |
+| `merge_leftmost_sink_branch.mmd`       | Merge where the sink section is the leftmost section in its row - tests that the merge trunk does not overshoot left                          |
+| `merge_offrow_continuation.mmd`        | Merge continuation that lands off the trunk row - tests that the continuation trunk is re-anchored to the correct row                         |
+| `merge_port_above_approach.mmd`        | Merge port approached from above - tests the above-approach routing arm for a merge entry                                                     |
+| `merge_pullaway.mmd`                   | Merge trunk pull-away across a cross-row sibling - tests that the trunk stays clear of the sibling section's bounding box                     |
+| `merge_right_entry.mmd`                | Merge feeder arriving via a cross-row RIGHT entry - tests the interaction of RIGHT-entry routing with merge-trunk continuation                |
+| `merge_trunk_out_of_range_section.mmd` | Merge trunk passing over a section outside its x-range - tests that the trunk does not clip sections it should not cross                      |
+| `merge_trunk_over_low_section.mmd`     | Merge trunk passing over a lower section - tests clear-corridor routing for trunks that cross over shorter sections                           |
+| `post_convergence_trunk.mmd`           | Trunk continuation after a convergence fold - tests that the post-convergence section inherits the correct trunk row and bundle offsets       |
+| `reconverge_reversed_fold.mmd`         | Reconvergence from a reversed fold (#705) - tests that the back-run after a reversed fold stays level and the fan/merge order is preserved    |
+| `merge_adjacent_feeder.mmd`            | A clear adjacent feeder reaching the merge directly instead of detouring onto the trunk approach                                              |
+| `merge_feeder_shared_channel_gap.mmd`  | Two merge feeders sharing one co-located descent channel between fan sources - each still gets its own gap slot (#1495)                       |
+| `merge_feeders_three_columns.mmd`      | Report feeders arriving from three separate columns - each lands on the trunk it converges onto                                               |
+| `fanin_distant_terminus.mmd`           | Same-layer fan-in siblings merging locally before running on to a distant file terminus                                                       |
+| `fanin_join_diff_length_branches.mmd`  | Sectionless four-line fan-in with branches of different lengths - the straight-diamond join does not snap onto a contested base track (#1456) |
 
 ### Off-track / rail-mode / misc routing
 
-| Fixture                               | What it tests                                                                                                                                                                    |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `clear_channel_target_aware_push.mmd` | Fan-descent target-aware channel push - the pushed descent lands on the target's side of the grazed section (#736)                                                               |
-| `disjoint_sameline_trunks.mmd`        | Two separate trunks for the same line in disjoint sections - tests that same-line bypass trunks do not falsely merge                                                             |
-| `off_track_input_above_consumer.mmd`  | Off-track file input positioned above its consumer - tests the above-consumer routing arm for off-track inputs                                                                   |
-| `peeloff_extra_line_consumer.mmd`     | Peel-off where an extra line has its own consumer in the target section - tests that the extra-consumer line peels correctly from the bundle                                     |
-| `peeloff_riser_respace.mmd`           | Peel-off riser respacing - tests that risers are re-spaced after a peel-off to maintain visual separation                                                                        |
-| `terminus_join.mmd`                   | Terminus join - two lines converging at a file terminus node; tests that the join routes cleanly when the terminus has a `%%metro file:` directive                               |
-| `rail_boundary_bundle_fan.mmd`        | Bundled section feeding a per-section rail section - each incoming line fans from the entry-port lane stack onto its own rail (issue #1624)                                      |
-| `rail_offtrack_fan.mmd`               | Rail-mode off-track fan-out - tests fan-out geometry under the `line_spread: rails` directive                                                                                    |
-| `rail_offtrack_io.mmd`                | Rail-mode off-track file input and output nodes - tests that rail-mode does not disturb off-track I/O node placement                                                             |
-| `rail_offtrack_plain_io.mmd`          | Rail-mode with plain (non-file) off-track I/O - tests the same path without the `%%metro file:` directive                                                                        |
-| `rail_horizontal_labels.mmd`          | Rail-mode section whose top-rail stations keep the default horizontal label angle - tests that the content-hug top target reflects rail mode's deliberate label-band hug (#1625) |
-| `rail_symmetric_fork_join_spans.mmd`  | Rail-mode plus `diamond_style: symmetric` - tests that a fork and join spanning different rail counts keep their own span centres                                                |
+| Fixture                                     | What it tests                                                                                                                                                                    |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `clear_channel_target_aware_push.mmd`       | Fan-descent target-aware channel push - the pushed descent lands on the target's side of the grazed section (#736)                                                               |
+| `disjoint_sameline_trunks.mmd`              | Two separate trunks for the same line in disjoint sections - tests that same-line bypass trunks do not falsely merge                                                             |
+| `off_track_input_above_consumer.mmd`        | Off-track file input positioned above its consumer - tests the above-consumer routing arm for off-track inputs                                                                   |
+| `peeloff_extra_line_consumer.mmd`           | Peel-off where an extra line has its own consumer in the target section - tests that the extra-consumer line peels correctly from the bundle                                     |
+| `peeloff_riser_respace.mmd`                 | Peel-off riser respacing - tests that risers are re-spaced after a peel-off to maintain visual separation                                                                        |
+| `terminus_join.mmd`                         | Terminus join - two lines converging at a file terminus node; tests that the join routes cleanly when the terminus has a `%%metro file:` directive                               |
+| `rail_boundary_bundle_fan.mmd`              | Bundled section feeding a per-section rail section - each incoming line fans from the entry-port lane stack onto its own rail (issue #1624)                                      |
+| `rail_offtrack_fan.mmd`                     | Rail-mode off-track fan-out - tests fan-out geometry under the `line_spread: rails` directive                                                                                    |
+| `rail_offtrack_io.mmd`                      | Rail-mode off-track file input and output nodes - tests that rail-mode does not disturb off-track I/O node placement                                                             |
+| `rail_offtrack_plain_io.mmd`                | Rail-mode with plain (non-file) off-track I/O - tests the same path without the `%%metro file:` directive                                                                        |
+| `rail_horizontal_labels.mmd`                | Rail-mode section whose top-rail stations keep the default horizontal label angle - tests that the content-hug top target reflects rail mode's deliberate label-band hug (#1625) |
+| `rail_symmetric_fork_join_spans.mmd`        | Rail-mode plus `diamond_style: symmetric` - tests that a fork and join spanning different rail counts keep their own span centres                                                |
+| `off_track_terminal_noop.mmd`               | An off-track terminal output with nothing downstream to protect - the off-track pass is a no-op here                                                                             |
+| `offtrack_output_peel_before_successor.mmd` | A dead-end off-track output peeled off before its producer's next station rather than after it                                                                                   |
+| `rail_inter_section.mmd`                    | Two `line_spread: rails` sections joined by an inter-section connector routed through a clean corridor (#975)                                                                    |
+| `interchange_label_clears_bridge.mmd`       | An interchange label sitting on its own connector bridge - the label is cleared off the bridge glyph                                                                             |
+| `render_labelwrap_row_gap.mmd`              | Render-time label wrap grows a section bbox, so the rows below it reflow to keep the gap                                                                                         |
+| `wrap_return_canvas_margin.mmd`             | Five-line bundle wrapping from a row-0 pair down into a row-1 section - the canvas grows for ink drawn outside the box envelope                                                  |
+| `bundle_terminator_continuation.mmd`        | A station that terminates one line of a two-line bundle - its sole successor stays on the trunk row (#979)                                                                       |
+| `corridor_fed_trunk_output_spur.mmd`        | A corridor-fed entry riding its through-chain rather than a short output spur off the trunk                                                                                      |
+| `section_trunk_short_output_branch.mmd`     | A section trunk choosing the long main chain over a short output spur (#1487)                                                                                                    |
+| `near_edge_exit_corner.mmd`                 | An exit corner close to the section edge - the corner stays inside the section bbox (#1314)                                                                                      |
+| `exit_fan_label_strike.mmd`                 | An exit fan in a coverage section whose branch runs against a station label                                                                                                      |
+| `side_branch_ascent_label_strike.mmd`       | Dedicated coverage for the ascending-side-branch label strike (#1449)                                                                                                            |
 
 ### TB section routing variants
 
-| Fixture                    | What it tests                                                                                                                                                                                                                                   |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tb_passthrough_trunk.mmd` | TB section acting as a pass-through trunk (no internal fork) - tests that a TB section with a straight trunk routes cleanly end to end                                                                                                          |
-| `tb_right_entry_stack.mmd` | TB section with a stacked RIGHT-entry - multiple lines entering a TB section from the right in a stacked configuration                                                                                                                          |
-| `tb_trunk_through_fan.mmd` | TB section with an internal fan-out where the trunk continues through - tests the TB analogue of `trunk_through_fan`                                                                                                                            |
-| `left_exit_sink_below.mmd` | A TB bridge's LEFT exit feeds a LEFT-entry sink one row below and to the left - the bundle leads out left and drops straight down a channel clear of both boxes, routing around the bridge instead of clawing back through its interior (#1083) |
+| Fixture                                    | What it tests                                                                                                                                                                                                                                   |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tb_passthrough_trunk.mmd`                 | TB section acting as a pass-through trunk (no internal fork) - tests that a TB section with a straight trunk routes cleanly end to end                                                                                                          |
+| `tb_right_entry_stack.mmd`                 | TB section with a stacked RIGHT-entry - multiple lines entering a TB section from the right in a stacked configuration                                                                                                                          |
+| `tb_trunk_through_fan.mmd`                 | TB section with an internal fan-out where the trunk continues through - tests the TB analogue of `trunk_through_fan`                                                                                                                            |
+| `left_exit_sink_below.mmd`                 | A TB bridge's LEFT exit feeds a LEFT-entry sink one row below and to the left - the bundle leads out left and drops straight down a channel clear of both boxes, routing around the bridge instead of clawing back through its interior (#1083) |
+| `tb_bottom_exit_bundle_jog.mmd`            | Four distinct lines leaving a TB section's BOTTOM exit into an RL target - each keeps its own channel through the jog                                                                                                                           |
+| `tb_column_continuation_two_lines.mmd`     | Two TB sections stacked in one column - lane offsets are preserved across the continuation seam                                                                                                                                                 |
+| `tb_convergence_straight_drop.mmd`         | A collinear feeder dropping straight into a TB convergence rather than doglegging (#1007, #1009)                                                                                                                                                |
+| `tb_passthrough_continuation.mmd`          | A pass-through TB convergence whose continuation drops straight (#1012)                                                                                                                                                                         |
+| `tb_perp_exit_side_neighbour.mmd`          | A TB BOTTOM exit into an LR neighbour that is beside it rather than below - the route goes down and over                                                                                                                                        |
+| `tb_two_line_vert_seam.mmd`                | Two TB sections side by side - the two-line LEFT/RIGHT entry lifts above the vertical-flow trunk head (#1054)                                                                                                                                   |
+| `tb_offtrack_fork_baseline.mmd`            | A TB asymmetric fork whose branch reaches further toward the lift side than the trunk - the off-track baseline anchors on the trunk column, not the lift-most station (#1388)                                                                   |
+| `tb_bottom_exit_fork_diamond.mmd`          | Three TB sections forming a diamond off one BOTTOM exit - the junction-fed TOP entry drops straight in its own column (#1058)                                                                                                                   |
+| `rowmate_tb_side_entry_top_align.mmd`      | A six-line pipeline whose side-entered TB section top-aligns with its row-mate (#1267)                                                                                                                                                          |
+| `rowmate_tb_side_entry_top_align_grow.mmd` | The same top alignment where the feeder section has grown, so the TB section aligns to the grown feeder                                                                                                                                         |
+
+### Fold and serpentine
+
+| Fixture                                    | What it tests                                                                                                                                  |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `branch_fold_forward.mmd`                  | A wide side branch at its fold threshold - the folded branch keeps flowing forward instead of reversing (#1080)                                |
+| `convergence_fold_diamond.mmd`             | Two branches reconverging across a fold - distinct lines fan onto parallel channels at the folded perpendicular entry (#1144)                  |
+| `fold_split_targets.mmd`                   | The fan-out half of the same folded perpendicular entry, one source splitting to two folded branch targets (#1144)                             |
+| `fold_left_exit_right_entry.mmd`           | A folded LEFT-exit staircase into a RIGHT entry - the three-line bundle stays ordered and concentric round the fold (#1143)                    |
+| `foldback_exit_peeloff.mmd`                | Seven-section variant-calling map at `fold_threshold: 15` - fold reversal propagates through a peel-off junction on the fold-back exit (#1199) |
+| `manual_rl_row_nonconsumer_bypass.mmd`     | The same map with manual RL row directions - a same-row RL bypass routes around an intervening non-consumer section (#1211)                    |
+| `packed_cell_cellmate_bypass_adjacent.mmd` | The same map again with the bypass source adjacent to the packed cell-mate it has to bypass                                                    |
+| `serpentine_grid_tall_bundle.mmd`          | Six-section left-to-right serpentine carrying a tall two-line bundle - the bundle stays fanned through the grid fold                           |
+| `serpentine_grid_wide_bundle.mmd`          | The wide-bundle member of the same serpentine pair                                                                                             |
+| `serpentine_rl_bundle.mmd`                 | A six-section serpentine written with explicit `direction: RL` rows rather than inferred folds                                                 |
+| `riboseq_fold_two_dir_entry.mmd`           | A six-section riboseq fold whose target is entered from two directions, with the entry sides hinted                                            |
+| `riboseq_fold_two_dir_entry_hintless.mmd`  | The same fold with no entry hints - tests geometry-aware entry-side inference (#1342)                                                          |
+| `packed_multiline_serpentine_grid.mmd`     | Eight sections and seven file nodes packed into a multi-row serpentine grid, with conflicting entry hints on the same target                   |
+| `same_side_culdesac.mmd`                   | A producer feeding an RL cul-de-sac section that leaves on the side it entered (#1182)                                                         |
+
+### Packed cells and shared grid cells
+
+| Fixture                                           | What it tests                                                                                                         |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `packed_cell_cellmate_bypass_cross_row.mmd`       | A cross-row descent blocked by a packed cell-mate, which the descent bypasses                                         |
+| `packed_cell_cellmate_bypass_entry_y.mmd`         | A packed cell-mate standing on the target's entry Y - the feed bypasses it rather than running through it             |
+| `packed_cell_consumer_drop_in.mmd`                | A packed-cell consumer dropped into from the row above - locks the entry-side inference for the drop-in (#1311)       |
+| `packed_cell_left_entry_blocked_top_corridor.mmd` | A packed-cell LEFT-entry wrap whose row-top corridor is blocked by a spanning obstacle section                        |
+| `packed_cell_left_entry_under_neighbour.mmd`      | A fan bypass descending into a packed-cell LEFT entry through the gap beside the source's cell-neighbour (#1486)      |
+| `packed_cell_right_exit_left_entry_wrap.mmd`      | The nf-core/genomeassembler map - seven sections and eight lines whose RIGHT exit wraps into a packed-cell LEFT entry |
+| `multi_section_cell.mmd`                          | Seven sections of mixed height packed into shared grid cells as one connected component                               |
+
+### Fan-out, fan-in and diamond geometry
+
+| Fixture                                     | What it tests                                                                                                                                                 |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fanout_bundle_plus_spurs.mmd`              | A fan-out bundle plus two single-line spur sections - each corridor-fed single-line section anchors on its own trunk                                          |
+| `fanout_hub_two_line_trunk.mmd`             | A symmetric fan-out hub on a two-line trunk with file outputs on every branch - exit-port re-centring and stacked-row top padding                             |
+| `fanout_intersection_shared_channel.mmd`    | One source fanning to two stacked sections whose feeds share a horizontal inter-section channel before peeling into a TOP entry and a LEFT entry              |
+| `fanout_line_reused_nonadjacent_leg.mmd`    | A fan whose line is reused on two non-adjacent legs - it is assigned a single contiguous lane (#1529)                                                         |
+| `fan_top_entry_over_tall_section.mmd`       | A fan's TOP-entry branch crossing over a tall section in the row above - the fan corridor band is measured across every column its gap branches cross (#1486) |
+| `same_line_fan_distinct_descent.mmd`        | A same-line fan-out with distinct descents, which bundle eagerly rather than descending separately (#1409)                                                    |
+| `straddling_fanout_junction.mmd`            | A fan-out junction straddling its targets - the divergent branch peels off to the left                                                                        |
+| `near_vertical_junction_hook.mmd`           | A fan-out junction dropping straight into a RIGHT entry in the same column (#1018)                                                                            |
+| `out_of_section_retag_fan.mmd`              | A branch retagged out of its section - the in-section fan is preserved (#1426)                                                                                |
+| `internal_source_equal_sibling_2fan.mmd`    | A two-way fan from a blank internal source station with equal-length siblings, which centres on the source                                                    |
+| `symmetric_deadend_fanout.mmd`              | A `diamond_style: symmetric` dead-end fan straddling a fixed entry-port trunk (#1299)                                                                         |
+| `symmetric_deadend_fanout_deep.mmd`         | The deeper member of that family - the dead-end branches run further before terminating                                                                       |
+| `symmetric_deadend_fanout_exit.mmd`         | The same fan in a section that also carries an exit into a sink                                                                                               |
+| `symmetric_deadend_fanout_relay.mmd`        | The same fan with a relay station between the hub and the dead ends                                                                                           |
+| `symmetric_diamond_bundle_padding.mmd`      | A six-line symmetric diamond - the section bbox padding reserves the real bundle-pill edge                                                                    |
+| `symmetric_diamond_odd_slot_entry.mmd`      | A reconverging symmetric diamond entered on an odd slot - the entry port centres on the fork midpoint (#1459)                                                 |
+| `symmetric_join_exit_port_centre.mmd`       | A two-way symmetric join whose exit port seats on its branches' centreline                                                                                    |
+| `symmetric_multiline_merge_median.mmd`      | A symmetric multi-track merge anchored on the median feeder track                                                                                             |
+| `ported_symmetric_fan_centreline_trunk.mmd` | A symmetric fan whose centreline is carried out to its ports and its downstream trunk                                                                         |
+| `paired_input_fan_branch_tree.mmd`          | A symmetric branch tree from a paired input set - an orphaned half-pitch branch seats on a full grid row                                                      |
+| `fork_join_interior_label.mmd`              | A six-line symmetric fork-join whose interior branch carries a label (#1259)                                                                                  |
+| `shared_cell_fork_trunk_align.mmd`          | A `diamond_style: straight` fan sharing a grid cell - the trunk holds the continuing branch (#1426)                                                           |
+
+### Exit lanes and exit-turn frames
+
+| Fixture                                      | What it tests                                                                                                   |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `exit_lane_settlement_without_crossings.mmd` | Five lines through one settling source - the exit lane frame settles with no crossings to resolve               |
+| `exit_lane_swap_shared_exit_port.mmd`        | The same five-line arrangement where two lanes swap through the shared exit port                                |
+| `exit_turn_frame_filters.mmd`                | A three-line seam source, target and side branch - the filters that decide which turns join one exit-turn frame |
+| `external_owner_exit_lane_frame.mmd`         | An exit lane frame with an owner outside it, fed by a vertical prelude section                                  |
+| `multi_frame_exit_lane_settlement.mmd`       | Fourteen sections and twelve lines forming several independent exit lane frames that settle separately          |
+| `target_lane_transition.mmd`                 | A lane transition taken on the target side of the seam rather than at the source exit                           |
+| `plan_owned_distinct_lane_separation.mmd`    | Seven RL sections sharing one source - planned lane separation is enforced for distinct lines                   |
+| `aligner_row_pinned_continuation.mmd`        | Sibling aligner sections stacked evenly over a pinned continuation                                              |
+| `aligner_row_terminator_lane_gap.mmd`        | The same aligner row where a sibling line does not exit - its lane leaves no phantom gap at the exit port       |
+| `single_line_dual_source_stacked_exit.mmd`   | One line leaving a section from two sources stacked in a column - the exit anchors on the feeder row            |
+
+### Inter-row corridors and drop channels
+
+| Fixture                                     | What it tests                                                                                              |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `inter_row_drop_section_clearance.mmd`      | An inter-row drop channel squeezed between packed sections above and below, centred in the gap it has      |
+| `inter_row_drop_section_clearance_row1.mmd` | The same drop where the row-1 sections hug the channel instead                                             |
+| `inter_row_exempt_band_order.mmd`           | An inter-row trunk band whose members are all exempt - reordering it removes crossings                     |
+| `opposing_bypass_corridor.mmd`              | Two bypass corridors running in opposite directions through the same inter-row gap, separated by direction |
+| `opposing_return_row_pair.mmd`              | A pair of opposed return-row routes out of one collecting section                                          |
+| `straight_drop_below.mmd`                   | A straight drop into the section directly below, with a LEFT-exit departure at the port seam               |
+| `peeloff_straight_drop_near_wall.mmd`       | A peel-off dropping straight into a section below, close to the section wall (#1521)                       |
+
+### Orientation and seam-rotation orbits
+
+| Fixture                              | What it tests                                                                             |
+| ------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `orbit_perp_exit_flow_entry.mmd`     | Perpendicular exit into a flow-aligned entry across three LR sections                     |
+| `orbit_perp_exit_perp_entry.mmd`     | Perpendicular exit into a perpendicular entry                                             |
+| `orbit_perp_exit_turning_entry.mmd`  | Perpendicular exit into a turning flow - an LR section feeding a TB report                |
+| `orbit_perp_exit_back_row_entry.mmd` | Perpendicular exit feeding a section in the row behind, through an LR-TB-LR chain (#1545) |
+
+### BT section routing
+
+| Fixture                             | What it tests                                                                                                           |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `bt_chain.mmd`                      | Minimal `direction: BT` section - a station chain flowing bottom to top, the base case for BT intra-section flow        |
+| `bt_fork.mmd`                       | Two lines forking from a shared station inside a BT section                                                             |
+| `bt_infer_ports.mmd`                | A BT section with no explicit port directives - tests BT direction inference and frame-symmetric port placement (#1442) |
+| `bt_exit_top_above.mmd`             | A BT section exiting through its TOP port into an LR section above it (#1044)                                           |
+| `bt_exit_top_above_2line.mmd`       | Two-line member of that seam - the fan's perpendicular-entry crossing X is chosen by feeder lane sign (#1066)           |
+| `bt_perp_entry_below.mmd`           | A BT section fed perpendicularly from a BT section below it                                                             |
+| `bt_perp_left_entry_right_exit.mmd` | Four BT sections with LEFT entry and RIGHT exit ports - the perpendicular entry seats before the flow-start end         |
+| `bt_to_lr.mmd`                      | A BT section leaving through a perpendicular port into an LR section                                                    |
+| `bt_to_tb.mmd`                      | A BT section feeding a TB section - opposed flow axes either side of one seam                                           |


### PR DESCRIPTION
`examples/topologies/README.md` named 155 of the 284 `.mmd` fixtures in the directory. This PR adds an entry for the other 129, so every fixture on disk is now named in the catalogue.

## Counts

| | Before | After |
| --- | --- | --- |
| Fixtures on disk | 284 | 284 |
| Named in the README | 155 | 284 |
| Rows in the Regression Catalogue | 78 | 207 |

## How the entries were derived

For each uncatalogued fixture: its `%%metro title:`, its own leading `%%` header comments (several carry the regression issue number and a full explanation), its `%%metro` directives, section names, line count and edge structure, plus `git log -1 --format=%s` on the file. Where a fixture cites an issue in its header or in the commit that added it, the entry cites that number.

No intent was invented. Fixtures whose purpose is not stated in any of those sources get a factual description of their shape (for example "Seven sections of mixed height packed into shared grid cells as one connected component") rather than a guessed rationale. Fourteen entries are shape-only in that sense; the rest carry a purpose taken from the fixture header or the commit subject.

Entries extend the existing themed tables (bypass, perpendicular drop, header placement, left/right entry, merge, off-track/misc, TB) and add seven new ones: fold and serpentine, packed cells and shared grid cells, fan-out/fan-in and diamond geometry, exit lanes and exit-turn frames, inter-row corridors and drop channels, orientation and seam-rotation orbits, and BT sections.

The intro, the structural-class-index blurb and the Regression Catalogue blurb are updated to match the new totals. A note near the top records that `tests/test_topology_validation.py` and `tests/test_layout_invariants.py` both glob the whole directory, so a fixture is exercised whether or not it is catalogued, and that `scripts/list_topology_fixtures.py` names any fixture this file has missed (verified: the script does exactly that).

No fixture was renamed, moved or edited. The only changed file is the README.

## Verification

- `python scripts/list_topology_fixtures.py` reports `Total fixtures: 284 / In README: 284 / Not in README: 0`.
- Every `*.mmd` basename cited in the README exists on disk (scripted check, 282 distinct names cited, zero misses; the remaining two fixtures are named through their illustration filenames in the walkthrough sections).
- `npx prettier --no-config --write examples/topologies/README.md` applied, then both checks re-run on the formatted file.
- Added text contains no em dashes.

## CLAUDE.md

The topology bullet now says the README catalogues every fixture and that `scripts/list_topology_fixtures.py` reports any that go missing from it. The sentence about the sweep globbing the directory is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
