### PR TITLE
refactor(themes): name theme constants by brand and mode

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -270,16 +270,16 @@ nf-metro serve [OPTIONS] INPUT_FILE [-- LAUNCH_CMD...]
 
 Stations are tied to processes with `%%metro process:` directives in the map, so only mapped stations change state. Everything about the event format, the overlay styles, and the endpoints is covered in [Live progress](/nf-metro/live/).
 
-| Option                              | Default       | Description                                                                                            |
-| ----------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------ |
-| `--port INTEGER`                    | 8080          | Port to listen on                                                                                      |
-| `--host TEXT`                       | `127.0.0.1`   | Interface to bind. The default is local only; use `0.0.0.0` to accept connections from other hosts     |
-| `--theme TEXT`                      | from `style:` | Theme name (`nfcore`, `light`, and the other `render --theme` names)                                   |
-| `--overlay [ring\|pulse\|dot\|led]` | `ring`        | Status-overlay style shown until a viewer picks another in the page                                    |
-| `--token TEXT`                      | none          | If set, `/events` POSTs must supply `?token=...` or an `X-Metro-Token` header                          |
-| `--open`                            | off           | Open the live page in a browser                                                                        |
-| `--shutdown-after-complete`         | off           | Stop the server shortly after the run's completed or error event (or after the launched command exits) |
-| `--shutdown-grace FLOAT`            | 10            | Seconds to keep the map up after the run finishes, with `--shutdown-after-complete`                    |
+| Option                                                                                  | Default       | Description                                                                                            |
+| --------------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------ |
+| `--port INTEGER`                                                                        | 8080          | Port to listen on                                                                                      |
+| `--host TEXT`                                                                           | `127.0.0.1`   | Interface to bind. The default is local only; use `0.0.0.0` to accept connections from other hosts     |
+| `--theme [nfcore\|nfcore-light\|nfcore-dark\|seqera\|seqera-light\|seqera-dark\|light]` | from `style:` | Visual theme, the same choices as `render --theme`                                                     |
+| `--overlay [ring\|pulse\|dot\|led]`                                                     | `ring`        | Status-overlay style shown until a viewer picks another in the page                                    |
+| `--token TEXT`                                                                          | none          | If set, `/events` POSTs must supply `?token=...` or an `X-Metro-Token` header                          |
+| `--open`                                                                                | off           | Open the live page in a browser                                                                        |
+| `--shutdown-after-complete`                                                             | off           | Stop the server shortly after the run's completed or error event (or after the launched command exits) |
+| `--shutdown-grace FLOAT`                                                                | 10            | Seconds to keep the map up after the run finishes, with `--shutdown-after-complete`                    |
 
 With an SVG input the map is served exactly as drawn, so `--theme` applies only to a `.mmd` input.
 
@@ -304,13 +304,13 @@ Run a persistent live server many pipelines can report into. Unlike `serve`, it 
 nf-metro serve-multi [OPTIONS]
 ```
 
-| Option                              | Default     | Description                                                                                        |
-| ----------------------------------- | ----------- | -------------------------------------------------------------------------------------------------- |
-| `--port INTEGER`                    | 8080        | Port to listen on                                                                                  |
-| `--host TEXT`                       | `127.0.0.1` | Interface to bind. The default is local only; use `0.0.0.0` to accept connections from other hosts |
-| `--theme TEXT`                      | `nfcore`    | Theme name (`nfcore`, `light`, and the other `render --theme` names)                               |
-| `--overlay [ring\|pulse\|dot\|led]` | `ring`      | Status-overlay style shown until a viewer picks another in the page                                |
-| `--token TEXT`                      | none        | If set, POSTs to `/maps` and `/r/*/events` must supply `?token=...` or an `X-Metro-Token` header   |
+| Option                                                                                  | Default     | Description                                                                                        |
+| --------------------------------------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------- |
+| `--port INTEGER`                                                                        | 8080        | Port to listen on                                                                                  |
+| `--host TEXT`                                                                           | `127.0.0.1` | Interface to bind. The default is local only; use `0.0.0.0` to accept connections from other hosts |
+| `--theme [nfcore\|nfcore-light\|nfcore-dark\|seqera\|seqera-light\|seqera-dark\|light]` | `nfcore`    | Visual theme, the same choices as `render --theme`                                                 |
+| `--overlay [ring\|pulse\|dot\|led]`                                                     | `ring`      | Status-overlay style shown until a viewer picks another in the page                                |
+| `--token TEXT`                                                                          | none        | If set, POSTs to `/maps` and `/r/*/events` must supply `?token=...` or an `X-Metro-Token` header   |
 
 The nf-metro Nextflow plugin's `metro.server` mode does the register-and-emit automatically. See [Live progress](/nf-metro/live/#2b-persistent-server-many-runs).
 

--- a/docs/dev/render.md
+++ b/docs/dev/render.md
@@ -241,7 +241,7 @@ so no ball restarts while another is mid-track.
 
 ## Theming (`style.py`)
 
-`Theme` is a frozen dataclass of visual properties: colours, font sizes,
+`Theme` is a keyword-only dataclass of visual properties: colours, font sizes,
 line widths, station radii, animation speed, and legend layout.
 
 Brand identity and display mode are orthogonal axes. Built-in themes live in

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -936,7 +936,13 @@ def explain(
     help="Interface to bind. Default 127.0.0.1 (local only); "
     "use 0.0.0.0 to accept connections from other hosts.",
 )
-@click.option("--theme", type=str, default=None, help="Theme name (nfcore, light).")
+@click.option(
+    "--theme",
+    type=click.Choice(list(THEMES.keys())),
+    default=None,
+    help="Visual theme (default: from the %%metro style: directive, else nfcore). "
+    "Applies to a .mmd input; an SVG input is served as drawn.",
+)
 @click.option(
     "--overlay",
     type=click.Choice(OVERLAY_STYLES),
@@ -1069,7 +1075,13 @@ def serve(
     help="Interface to bind. Default 127.0.0.1 (local only); "
     "use 0.0.0.0 to accept connections from other hosts.",
 )
-@click.option("--theme", type=str, default="nfcore", help="Theme name (nfcore, light).")
+@click.option(
+    "--theme",
+    type=click.Choice(list(THEMES.keys())),
+    default="nfcore",
+    show_default=True,
+    help="Visual theme applied to every map registered with this server.",
+)
 @click.option(
     "--overlay",
     type=click.Choice(OVERLAY_STYLES),
@@ -1101,10 +1113,6 @@ def serve_multi_cmd(
     """
     from nf_metro.live.server import serve_multi
 
-    if theme not in THEMES:
-        raise click.ClickException(
-            f"unknown theme {theme!r}; choose from {list(THEMES)}"
-        )
     if host == "0.0.0.0":  # noqa: S104 - explicit opt-in, warned
         click.echo(
             "Binding 0.0.0.0: reachable from other hosts; "

--- a/src/nf_metro/themes/__init__.py
+++ b/src/nf_metro/themes/__init__.py
@@ -13,21 +13,15 @@ from typing import TYPE_CHECKING
 
 from nf_metro.render.style import Theme
 from nf_metro.themes.light import LIGHT_THEME
-from nf_metro.themes.nfcore import (
-    NFCORE_DARK_THEME,
-    NFCORE_LIGHT_THEME,
-    NFCORE_THEME,
-)
-from nf_metro.themes.seqera import (
-    SEQERA_DARK_THEME,
-    SEQERA_LIGHT_THEME,
-    SEQERA_THEME,
-)
+from nf_metro.themes.nfcore import NFCORE_DARK_THEME, NFCORE_LIGHT_THEME
+from nf_metro.themes.seqera import SEQERA_DARK_THEME, SEQERA_LIGHT_THEME
 
 if TYPE_CHECKING:
     from nf_metro.parser.model import MetroGraph
 
-# ``style: dark`` predates theme names; alias it onto the nfcore brand.
+# ``dark`` names a mode, not a brand, but it is both an accepted
+# ``%%metro style:`` value and ``MetroGraph.style``'s default, so every map
+# without a style directive arrives here; map it onto the nfcore brand.
 _STYLE_THEME_ALIASES = {"dark": "nfcore"}
 
 # Mode used when a single concrete palette must be baked and none was chosen
@@ -98,10 +92,8 @@ __all__ = [
     "resolve_theme",
     "mode_pair",
     "LIGHT_THEME",
-    "NFCORE_THEME",
-    "NFCORE_DARK_THEME",
     "NFCORE_LIGHT_THEME",
-    "SEQERA_THEME",
+    "NFCORE_DARK_THEME",
     "SEQERA_LIGHT_THEME",
     "SEQERA_DARK_THEME",
 ]

--- a/src/nf_metro/themes/nfcore.py
+++ b/src/nf_metro/themes/nfcore.py
@@ -51,5 +51,3 @@ NFCORE_LIGHT_THEME = replace(
     legend_background="rgba(255, 255, 255, 0.8)",
     legend_text_color="#333333",
 )
-
-NFCORE_THEME = NFCORE_DARK_THEME

--- a/src/nf_metro/themes/seqera.py
+++ b/src/nf_metro/themes/seqera.py
@@ -66,5 +66,3 @@ SEQERA_DARK_THEME = replace(
     legend_background="rgba(0, 0, 0, 0.4)",
     legend_text_color="#e0d9f7",
 )
-
-SEQERA_THEME = SEQERA_DARK_THEME

--- a/tests/test_auto_layout.py
+++ b/tests/test_auto_layout.py
@@ -524,12 +524,12 @@ def test_rnaseq_auto_renders():
     """rnaseq_auto.mmd (no directives) parses and renders without errors."""
     from nf_metro.layout.engine import compute_layout
     from nf_metro.render.svg import render_svg
-    from nf_metro.themes.nfcore import NFCORE_THEME
+    from nf_metro.themes import NFCORE_DARK_THEME
 
     text = (EXAMPLES / "rnaseq_auto.mmd").read_text()
     graph = parse_metro_mermaid(text)
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
 
     # Should produce valid SVG with all sections
     assert "<svg" in svg

--- a/tests/test_bare_render.py
+++ b/tests/test_bare_render.py
@@ -19,7 +19,7 @@ from nf_metro.render.constants import (
     WATERMARK_Y_INSET,
 )
 from nf_metro.render.svg import render_svg
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 _TITLED_MMD = (
     "%%metro title: My Pipeline\n"
@@ -50,29 +50,29 @@ def _title_text_elements(svg: str) -> list[ET.Element]:
 def test_bare_omits_title():
     """No title text element is rendered in bare output."""
     g = _graph(_TITLED_MMD)
-    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    bare_svg = render_svg(g, NFCORE_DARK_THEME, bare=True)
     assert _title_text_elements(bare_svg) == []
 
 
 def test_full_chrome_still_has_title():
     """Full-chrome render includes the title."""
     g = _graph(_TITLED_MMD)
-    full_svg = render_svg(g, NFCORE_THEME)
+    full_svg = render_svg(g, NFCORE_DARK_THEME)
     assert "My Pipeline" in full_svg
 
 
 def test_bare_keeps_watermark():
     """Watermark attribution must survive bare mode."""
     g = _graph(_TITLED_MMD)
-    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    bare_svg = render_svg(g, NFCORE_DARK_THEME, bare=True)
     assert "nf-metro" in bare_svg
 
 
 def test_bare_canvas_narrower_than_full():
     """Bare canvas must be narrower (right padding dropped)."""
     g = _graph(_TITLED_MMD)
-    full_svg = render_svg(g, NFCORE_THEME)
-    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    full_svg = render_svg(g, NFCORE_DARK_THEME)
+    bare_svg = render_svg(g, NFCORE_DARK_THEME, bare=True)
 
     full_width = int(ET.fromstring(full_svg).attrib["width"])
     bare_width = int(ET.fromstring(bare_svg).attrib["width"])
@@ -86,8 +86,8 @@ def test_bare_canvas_narrower_multi_section():
     if not _MULTI_SECTION_MMD.exists():
         pytest.skip("rnaseq_sections.mmd not found")
     g = _graph(_MULTI_SECTION_MMD.read_text())
-    full_svg = render_svg(g, NFCORE_THEME)
-    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    full_svg = render_svg(g, NFCORE_DARK_THEME)
+    bare_svg = render_svg(g, NFCORE_DARK_THEME, bare=True)
 
     full_width = int(ET.fromstring(full_svg).attrib["width"])
     bare_width = int(ET.fromstring(bare_svg).attrib["width"])
@@ -98,7 +98,7 @@ def test_bare_canvas_narrower_multi_section():
 def test_bare_viewbox_starts_at_origin():
     """viewBox must begin with '0 0' so overlay alignment is preserved."""
     g = _graph(_TITLED_MMD)
-    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    bare_svg = render_svg(g, NFCORE_DARK_THEME, bare=True)
     root = ET.fromstring(bare_svg)
     vb = root.attrib.get("viewBox", "")
     assert vb.startswith("0 0"), f"viewBox={vb!r} does not start at origin"
@@ -107,7 +107,7 @@ def test_bare_viewbox_starts_at_origin():
 def test_full_viewbox_starts_at_origin():
     """Full-chrome viewBox must also start at origin (no regression)."""
     g = _graph(_TITLED_MMD)
-    full_svg = render_svg(g, NFCORE_THEME)
+    full_svg = render_svg(g, NFCORE_DARK_THEME)
     root = ET.fromstring(full_svg)
     vb = root.attrib.get("viewBox", "")
     assert vb.startswith("0 0"), f"viewBox={vb!r} does not start at origin"
@@ -116,7 +116,7 @@ def test_full_viewbox_starts_at_origin():
 def test_bare_height_includes_watermark():
     """Height must accommodate the watermark even in bare mode."""
     g = _graph(_TITLED_MMD)
-    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    bare_svg = render_svg(g, NFCORE_DARK_THEME, bare=True)
     h = int(ET.fromstring(bare_svg).attrib["height"])
     assert h >= WATERMARK_Y_INSET + WATERMARK_FONT_SIZE
 
@@ -124,7 +124,7 @@ def test_bare_height_includes_watermark():
 def test_bare_is_valid_svg():
     """Bare output must be well-formed XML with an svg root."""
     g = _graph(_TITLED_MMD)
-    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    bare_svg = render_svg(g, NFCORE_DARK_THEME, bare=True)
     root = ET.fromstring(bare_svg)
     assert root.tag.endswith("svg") or "svg" in root.tag
 

--- a/tests/test_bridge_glyph.py
+++ b/tests/test_bridge_glyph.py
@@ -43,7 +43,7 @@ from nf_metro.render.svg import (
     apply_route_offsets,
     render_svg,
 )
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 TOPOLOGIES_DIR = EXAMPLES_DIR / "topologies"
@@ -423,7 +423,7 @@ graph LR
         polylines,
         radii,
         ((BridgeBreak(1, (100.0, 30.0), (100.0, 40.0)),),),
-        NFCORE_THEME,
+        NFCORE_DARK_THEME,
         CURVE_RADIUS,
     )
 
@@ -498,7 +498,7 @@ def test_rendered_under_line_has_pen_up():
     move (pen-up) - on ``main`` it is continuous."""
     graph = parse_metro_mermaid((EXAMPLES_DIR / "genomic_pipeline.mmd").read_text())
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     broken = [d for d in _edge_path_ds(svg) if d.count("M") > 1]
     assert broken, "expected at least one broken (bridged) under-line path"
 
@@ -508,7 +508,7 @@ def test_theme_toggle_disables_bridges():
 
     graph = parse_metro_mermaid((EXAMPLES_DIR / "genomic_pipeline.mmd").read_text())
     compute_layout(graph)
-    theme_off = dataclasses.replace(NFCORE_THEME, bridge_glyph=False)
+    theme_off = dataclasses.replace(NFCORE_DARK_THEME, bridge_glyph=False)
     svg = render_svg(graph, theme_off)
     assert not any(d.count("M") > 1 for d in _edge_path_ds(svg))
 
@@ -521,10 +521,12 @@ def test_animation_paths_flow_over_gaps():
 
     graph = parse_metro_mermaid((EXAMPLES_DIR / "genomic_pipeline.mmd").read_text())
     compute_layout(graph)
-    on = _motion_paths(render_svg(graph, NFCORE_THEME, animate=True))
+    on = _motion_paths(render_svg(graph, NFCORE_DARK_THEME, animate=True))
     off = _motion_paths(
         render_svg(
-            graph, dataclasses.replace(NFCORE_THEME, bridge_glyph=False), animate=True
+            graph,
+            dataclasses.replace(NFCORE_DARK_THEME, bridge_glyph=False),
+            animate=True,
         )
     )
     assert on and on == off

--- a/tests/test_css_custom_properties.py
+++ b/tests/test_css_custom_properties.py
@@ -16,12 +16,7 @@ from nf_metro.api import render_string
 from nf_metro.layout.engine import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render.svg import render_svg
-from nf_metro.themes import (
-    LIGHT_THEME,
-    NFCORE_DARK_THEME,
-    NFCORE_LIGHT_THEME,
-    NFCORE_THEME,
-)
+from nf_metro.themes import LIGHT_THEME, NFCORE_DARK_THEME, NFCORE_LIGHT_THEME
 
 _MMD = (
     "%%metro title: Test\n"
@@ -66,7 +61,7 @@ def _make_graph():
 )
 def test_svg_declares_chrome_property(prop):
     """Each recolorable chrome surface declares its ``--nfm-map-*`` property."""
-    svg = render_svg(_make_graph(), NFCORE_THEME)
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME)
     assert prop in svg
 
 
@@ -77,7 +72,7 @@ def test_svg_declares_chrome_property(prop):
 
 def test_chrome_css_fallbacks_are_light_dark_of_both_palettes():
     """Fallbacks pair the light and dark palette values via ``light-dark()``."""
-    svg = render_svg(_make_graph(), NFCORE_THEME)
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME)
     light, dark = NFCORE_LIGHT_THEME, NFCORE_DARK_THEME
     assert (
         f"--nfm-map-bg, light-dark({light.background_color}, {dark.background_color})"
@@ -103,13 +98,13 @@ def test_chrome_css_fallbacks_are_light_dark_of_both_palettes():
 
 def test_root_declares_color_scheme_for_mode_family():
     """A branded theme tags the root <svg> with ``color-scheme: light dark``."""
-    svg = render_svg(_make_graph(), NFCORE_THEME)
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME)
     assert "color-scheme: light dark" in svg
 
 
 def test_self_color_scheme_false_omits_root_color_scheme():
     """Inlined renders omit the root color-scheme so the page's choice wins."""
-    svg = render_svg(_make_graph(), NFCORE_THEME, self_color_scheme=False)
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME, self_color_scheme=False)
     assert "color-scheme" not in svg
 
 
@@ -129,7 +124,7 @@ def test_baked_mode_dark_narrows_color_scheme():
 
 def test_no_baked_mode_preserves_adaptive_color_scheme():
     """Without baked_mode the SVG stays adaptive (color-scheme: light dark)."""
-    svg = render_svg(_make_graph(), NFCORE_THEME)
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME)
     assert "color-scheme: light dark" in svg
 
 
@@ -172,7 +167,7 @@ def test_chrome_css_fallbacks_single_value_for_unfamilied_theme():
 def test_line_colors_not_in_chrome_css_vars():
     """Line colors must NOT appear inside CSS custom property declarations."""
     g = _make_graph()
-    svg = render_svg(g, NFCORE_THEME)
+    svg = render_svg(g, NFCORE_DARK_THEME)
     for line in g.lines.values():
         assert f"--nfm-map-line-{line.id}" not in svg
         assert line.color in svg
@@ -185,26 +180,26 @@ def test_line_colors_not_in_chrome_css_vars():
 
 def test_background_rect_has_nf_metro_bg_class():
     """The canvas background rect should carry the nf-metro-bg class."""
-    svg = render_svg(_make_graph(), NFCORE_THEME)
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME)
     assert "nf-metro-bg" in svg
 
 
 def test_chrome_css_uses_namespaced_class_selectors():
     """With svg_class_prefix, the chrome CSS selectors use the prefixed class names."""
-    svg = render_svg(_make_graph(), NFCORE_THEME, svg_class_prefix="mymap")
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME, svg_class_prefix="mymap")
     assert "mymap-nf-metro-bg" in svg
     assert ".nf-metro-bg" not in svg
 
 
 def test_legend_background_has_nf_metro_legend_bg_class():
     """The legend background rect should carry the nf-metro-legend-bg class."""
-    svg = render_svg(_make_graph(), NFCORE_THEME)
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME)
     assert "nf-metro-legend-bg" in svg
 
 
 def test_legend_text_has_nf_metro_legend_text_class():
     """Legend text entries should carry the nf-metro-legend-text class."""
-    svg = render_svg(_make_graph(), NFCORE_THEME)
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME)
     assert "nf-metro-legend-text" in svg
 
 
@@ -217,7 +212,7 @@ def test_icon_caption_uses_adaptive_label_color():
         "    source -->|main| node[Node]\n"
     )
     compute_layout(graph)
-    root = ET.fromstring(render_svg(graph, NFCORE_THEME))
+    root = ET.fromstring(render_svg(graph, NFCORE_DARK_THEME))
     caption = next(element for element in root.iter() if element.text == "Caption")
 
     assert "nf-metro-station-label" in caption.attrib.get("class", "").split()
@@ -230,28 +225,28 @@ def test_icon_caption_uses_adaptive_label_color():
 
 def test_chrome_css_false_omits_var_references():
     """chrome_css=False emits no var() so non-CSS-custom-property renderers cope."""
-    svg = render_svg(_make_graph(), NFCORE_THEME, chrome_css=False)
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME, chrome_css=False)
     assert "var(--nfm" not in svg
     assert "light-dark(" not in svg
 
 
 def test_chrome_css_false_keeps_concrete_chrome_colors():
     """Dropping the var() block leaves the resolved mode's colors baked on chrome."""
-    svg = render_svg(_make_graph(), NFCORE_THEME, chrome_css=False)
-    assert f'fill="{NFCORE_THEME.background_color}"' in svg
-    assert f'fill="{NFCORE_THEME.section_fill}"' in svg
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME, chrome_css=False)
+    assert f'fill="{NFCORE_DARK_THEME.background_color}"' in svg
+    assert f'fill="{NFCORE_DARK_THEME.section_fill}"' in svg
 
 
 def test_chrome_css_default_emits_var_block():
     """The default keeps the var() block so a host can recolor the map live."""
-    svg = render_svg(_make_graph(), NFCORE_THEME)
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME)
     assert "var(--nfm-map-bg" in svg
 
 
 def test_chrome_css_false_rasterizes_with_cairosvg():
     """chrome_css=False output is consumable by cairosvg, which cannot parse var()."""
     cairosvg = pytest.importorskip("cairosvg")
-    svg = render_svg(_make_graph(), NFCORE_THEME, chrome_css=False)
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME, chrome_css=False)
     png = cairosvg.svg2png(bytestring=svg.encode())
     assert png[:8] == b"\x89PNG\r\n\x1a\n"
 
@@ -284,7 +279,7 @@ def _make_marker_graph():
 
 def test_marker_stroke_css_property_declared():
     """``--nfm-map-marker-stroke`` must appear in the chrome CSS block."""
-    svg = render_svg(_make_marker_graph(), NFCORE_THEME)
+    svg = render_svg(_make_marker_graph(), NFCORE_DARK_THEME)
     assert "--nfm-map-marker-stroke" in svg
 
 
@@ -294,14 +289,14 @@ def test_marker_stroke_class_on_marker_elements():
     The baked hex remains as a presentation-attribute fallback for cairosvg; the CSS
     class rule overrides it in-browser (CSS stylesheet > presentation attributes).
     """
-    svg = render_svg(_make_marker_graph(), NFCORE_THEME)
+    svg = render_svg(_make_marker_graph(), NFCORE_DARK_THEME)
     assert "nf-metro-marker-stroke" in svg
     assert "var(--nfm-map-marker-stroke" in svg
 
 
 def test_marker_stroke_fallback_is_light_dark_of_both_palettes():
     """The --nfm-map-marker-stroke fallback pairs light and dark values."""
-    svg = render_svg(_make_marker_graph(), NFCORE_THEME)
+    svg = render_svg(_make_marker_graph(), NFCORE_DARK_THEME)
     light_val = NFCORE_LIGHT_THEME.marker_stroke or NFCORE_LIGHT_THEME.station_stroke
     dark_val = NFCORE_DARK_THEME.marker_stroke or NFCORE_DARK_THEME.station_stroke
     assert f"--nfm-map-marker-stroke, light-dark({light_val}, {dark_val})" in svg
@@ -309,7 +304,7 @@ def test_marker_stroke_fallback_is_light_dark_of_both_palettes():
 
 def test_marker_stroke_class_in_legend_swatches():
     """Legend marker swatches carry the ``nf-metro-marker-stroke`` class too."""
-    svg = render_svg(_make_marker_graph(), NFCORE_THEME)
+    svg = render_svg(_make_marker_graph(), NFCORE_DARK_THEME)
     # CSS rule + at least one station marker + at least one legend swatch
     count = svg.count("nf-metro-marker-stroke")
     assert count >= 3, f"Expected ≥3 occurrences (rule + station + swatch), got {count}"
@@ -317,6 +312,6 @@ def test_marker_stroke_class_in_legend_swatches():
 
 def test_chrome_css_false_marker_stroke_is_concrete():
     """chrome_css=False keeps the baked marker stroke for cairosvg rasterisation."""
-    svg = render_svg(_make_marker_graph(), NFCORE_THEME, chrome_css=False)
+    svg = render_svg(_make_marker_graph(), NFCORE_DARK_THEME, chrome_css=False)
     assert "var(--nfm-map-marker-stroke" not in svg
     assert 'stroke="' in svg

--- a/tests/test_debug_row_grid.py
+++ b/tests/test_debug_row_grid.py
@@ -23,7 +23,7 @@ from nf_metro.render.svg import (
     render_svg,
     station_marker_box,
 )
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 
@@ -68,7 +68,7 @@ def _anchor_ys(graph) -> set[float]:
     graph, so anchors read straight off the laid-out graph are the pre-render
     ones and would not line up with the drawn grid.
     """
-    settled = _settled_render_graph(graph, NFCORE_THEME)
+    settled = _settled_render_graph(graph, NFCORE_DARK_THEME)
     return {round(st.y, 1) for st in settled.stations.values() if not st.is_port}
 
 
@@ -77,7 +77,7 @@ def test_debug_row_grid_marks_placement_anchors(fixture):
     """Every occupied row has a grid line on its anchor, and no grid line sits
     where no station is placed."""
     graph = _laid_out(fixture)
-    svg = render_svg(graph, NFCORE_THEME, debug=True, chrome_css=False)
+    svg = render_svg(graph, NFCORE_DARK_THEME, debug=True, chrome_css=False)
     grid_ys = _row_grid_line_ys(svg)
     assert grid_ys, "debug render drew no row-grid lines"
     anchors = _anchor_ys(graph)
@@ -97,7 +97,7 @@ def test_debug_grid_sits_at_anchor_not_pill_centre():
     """The headline #589 case: the nine bundled qc_report stations share one
     anchor line at station.y, and their pills hang below it (centre != anchor)."""
     graph = _laid_out("rnaseq_sections_manual.mmd")
-    svg = render_svg(graph, NFCORE_THEME, debug=True, chrome_css=False)
+    svg = render_svg(graph, NFCORE_DARK_THEME, debug=True, chrome_css=False)
     grid_ys = _row_grid_line_ys(svg)
     offsets = compute_station_offsets(graph)
 
@@ -114,7 +114,7 @@ def test_debug_grid_sits_at_anchor_not_pill_centre():
     assert grid_at, f"no grid line at the qc_report anchor y={trunk_y}"
 
     for st in trunk:
-        _cx, cy, _w, _h, _r = station_marker_box(graph, NFCORE_THEME, st, offsets)
+        _cx, cy, _w, _h, _r = station_marker_box(graph, NFCORE_DARK_THEME, st, offsets)
         # The bundle offset puts the drawn pill centre below its anchor line.
         assert cy > trunk_y + EPS
         assert not any(abs(cy - g) <= EPS for g in grid_at)

--- a/tests/test_diagonal_labels.py
+++ b/tests/test_diagonal_labels.py
@@ -13,7 +13,7 @@ from nf_metro.layout.labels import find_label_overlaps, place_labels
 from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render.svg import render_svg
-from nf_metro.themes.nfcore import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 _EXAMPLE = Path(__file__).resolve().parents[1] / "examples" / "diagonal_labels.mmd"
 
@@ -99,7 +99,7 @@ graph LR
         compute_layout(graph)
     assert graph.label_angle == 0.0
 
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "rotate(" not in svg
 
 
@@ -224,7 +224,7 @@ def test_feeder_exits_right_of_section_box_not_through_bottom():
     """
     graph = parse_metro_mermaid(_EXAMPLE.read_text())
     compute_layout(graph, validate=True)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
 
     # Section 1 (Pre-processing) is the topmost wide section rect.  Exclude
     # the full-canvas background rect (anchored at the origin).

--- a/tests/test_directional_markers.py
+++ b/tests/test_directional_markers.py
@@ -12,7 +12,7 @@ from nf_metro.render.svg import (
     apply_route_offsets,
     render_svg,
 )
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 EXAMPLES_DIR = pathlib.Path(__file__).parent.parent / "examples"
 
@@ -33,7 +33,7 @@ def _laid_out(stem: str):
 def _render(stem: str, *, directional: bool) -> str:
     graph = _laid_out(stem)
     graph.directional = directional
-    return render_svg(graph, NFCORE_THEME)
+    return render_svg(graph, NFCORE_DARK_THEME)
 
 
 def test_directional_off_by_default_emits_no_chevrons():
@@ -58,8 +58,8 @@ def test_chevron_headings_point_downstream(stem):
     station_offsets = compute_station_offsets(graph)
     routes = route_edges_centred(graph, station_offsets=station_offsets)
 
-    spacing = NFCORE_THEME.directional_marker_spacing
-    min_length = 2 * NFCORE_THEME.directional_marker_size
+    spacing = NFCORE_DARK_THEME.directional_marker_spacing
+    min_length = 2 * NFCORE_DARK_THEME.directional_marker_size
 
     checked = 0
     for route in routes:

--- a/tests/test_exit_turn_planner.py
+++ b/tests/test_exit_turn_planner.py
@@ -68,7 +68,7 @@ from nf_metro.parser.model import LineSpread, PortSide
 from nf_metro.parser.route_topology import build_route_topology_query
 from nf_metro.render.plan import freeze_render_value
 from nf_metro.render.svg import station_marker_box
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 ROOT = Path(__file__).parents[1]
 TOPOLOGIES = ROOT / "examples" / "topologies"
@@ -836,9 +836,11 @@ def test_adjacent_local_terminator_does_not_inflate_entry_frame_pills() -> None:
 
     for station_id in ("before", "split"):
         _cx, _cy, _width, height, _radius = station_marker_box(
-            graph, NFCORE_THEME, graph.stations[station_id], offsets
+            graph, NFCORE_DARK_THEME, graph.stations[station_id], offsets
         )
-        assert height == pytest.approx(inherited_span + 2 * NFCORE_THEME.station_radius)
+        assert height == pytest.approx(
+            inherited_span + 2 * NFCORE_DARK_THEME.station_radius
+        )
 
 
 def test_station_offset_rebuild_clears_entry_pill_metadata_for_rail_mode() -> None:

--- a/tests/test_inactive_lines.py
+++ b/tests/test_inactive_lines.py
@@ -12,9 +12,9 @@ from nf_metro.render.constants import (
     effective_line_color,
     station_is_muted,
 )
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
-MUTED = NFCORE_THEME.muted_line_color
+MUTED = NFCORE_DARK_THEME.muted_line_color
 
 # Two lines, three stations: x touches only line a, z only line b, y both.
 TWO_LINE_MAP = (
@@ -63,7 +63,7 @@ def _label_fill_by_station(svg):
 
 
 def test_muted_line_color_defaults_to_fallback_grey():
-    assert NFCORE_THEME.muted_line_color == FALLBACK_LINE_COLOR
+    assert NFCORE_DARK_THEME.muted_line_color == FALLBACK_LINE_COLOR
 
 
 def test_effective_line_color_mutes_inactive_only():
@@ -71,9 +71,11 @@ def test_effective_line_color_mutes_inactive_only():
     a = graph.lines["a"]
     b = graph.lines["b"]
     inactive = frozenset({"a"})
-    assert effective_line_color(a, NFCORE_THEME, inactive) == MUTED
-    assert effective_line_color(b, NFCORE_THEME, inactive) == b.color
-    assert effective_line_color(None, NFCORE_THEME, inactive) == FALLBACK_LINE_COLOR
+    assert effective_line_color(a, NFCORE_DARK_THEME, inactive) == MUTED
+    assert effective_line_color(b, NFCORE_DARK_THEME, inactive) == b.color
+    assert (
+        effective_line_color(None, NFCORE_DARK_THEME, inactive) == FALLBACK_LINE_COLOR
+    )
 
 
 def test_station_is_muted_guards_zero_line_station():
@@ -129,8 +131,8 @@ def test_station_touched_by_active_line_not_muted():
     # y and z each touch an active line -> full-strength stroke + label.
     assert MUTED not in rects["y"]
     assert MUTED not in rects["z"]
-    assert labels["y"] == NFCORE_THEME.label_color
-    assert labels["z"] == NFCORE_THEME.label_color
+    assert labels["y"] == NFCORE_DARK_THEME.label_color
+    assert labels["z"] == NFCORE_DARK_THEME.label_color
 
 
 def test_muted_station_keeps_fill():
@@ -139,7 +141,7 @@ def test_muted_station_keeps_fill():
     for el in root.iter():
         if el.tag.endswith("rect") and el.get("data-station-id") == "x":
             # Fill is the theme station fill, not the muted grey.
-            assert el.get("fill") == NFCORE_THEME.station_fill
+            assert el.get("fill") == NFCORE_DARK_THEME.station_fill
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_legend_combo.py
+++ b/tests/test_legend_combo.py
@@ -8,7 +8,7 @@ import drawsvg as draw
 
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render.legend import render_legend
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 _BASE = (
     "%%metro line: normal | Normal | #2196F3\n"
@@ -25,7 +25,7 @@ def _parse(directives: str = ""):
 def _render_swatches_and_texts(graph):
     """Return (stroke_colors, label_texts) from a rendered legend SVG."""
     d = draw.Drawing(400, 400)
-    render_legend(d, graph, NFCORE_THEME, 0.0, 0.0)
+    render_legend(d, graph, NFCORE_DARK_THEME, 0.0, 0.0)
     svg = d.as_svg()
     colors = [
         line.split('stroke="', 1)[1].split('"', 1)[0]
@@ -81,7 +81,7 @@ def test_default_off_byte_identical_legend():
     """With no legend_combo directive the legend SVG is byte-identical."""
     graph = _parse()
     d = draw.Drawing(400, 400)
-    render_legend(d, graph, NFCORE_THEME, 0.0, 0.0)
+    render_legend(d, graph, NFCORE_DARK_THEME, 0.0, 0.0)
     svg = d.as_svg()
     colors, texts = _render_swatches_and_texts(graph)
     assert texts == ["Normal", "Tumor", "Quality Control"]

--- a/tests/test_legend_placement.py
+++ b/tests/test_legend_placement.py
@@ -18,7 +18,7 @@ from nf_metro.layout.routing import route_edges_centred
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render import svg as S
 from nf_metro.render.section_header import resolve_all_section_headers
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 EXAMPLES = Path(__file__).parent.parent / "examples"
 EXAMPLE_TOPOLOGIES = EXAMPLES / "topologies"
@@ -65,7 +65,7 @@ def _place(text: str):
     )
     res = S._position_legend(
         graph,
-        NFCORE_THEME,
+        NFCORE_DARK_THEME,
         max_x,
         max_y,
         S.CANVAS_PADDING,

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -27,7 +27,7 @@ from nf_metro.render.manifest import (
     read_manifest,
 )
 from nf_metro.render.svg import render_svg, station_marker_box
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 # A small map with sections, multiple lines, and a process mapping so every
 # manifest field is exercised.
@@ -57,7 +57,7 @@ graph LR
 @pytest.fixture
 def mapped_svg() -> str:
     graph = parse_and_layout(MAPPED_TEXT)
-    return render_svg(graph, NFCORE_THEME)
+    return render_svg(graph, NFCORE_DARK_THEME)
 
 
 def test_manifest_embedded_and_roundtrips(mapped_svg: str) -> None:
@@ -82,7 +82,7 @@ def test_no_manifest_opt_out_emits_drawn_map_only() -> None:
     """
     graph = parse_and_layout(MAPPED_TEXT)
     graph.embed_manifest = False
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
 
     ET.fromstring(svg)  # well-formed XML
     assert read_manifest(svg) is None
@@ -99,9 +99,9 @@ def test_no_manifest_drops_only_data_not_glyphs() -> None:
     ``data-node-*`` attributes.
     """
     graph = parse_and_layout(MAPPED_TEXT)
-    on = render_svg(graph, NFCORE_THEME)
+    on = render_svg(graph, NFCORE_DARK_THEME)
     graph.embed_manifest = False
-    off = render_svg(graph, NFCORE_THEME)
+    off = render_svg(graph, NFCORE_DARK_THEME)
 
     rects_on = on.count("<rect")
     rects_off = off.count("<rect")
@@ -121,7 +121,7 @@ def test_match_block_documents_semantics(mapped_svg: str) -> None:
 
 def test_nodes_coords_and_patterns_match_graph() -> None:
     graph = parse_and_layout(MAPPED_TEXT)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     manifest = read_manifest(svg)
 
     by_id = {n["id"]: n for n in manifest["nodes"]}
@@ -134,10 +134,10 @@ def test_nodes_coords_and_patterns_match_graph() -> None:
     offsets = compute_station_offsets(graph)
     for sid, entry in by_id.items():
         st = graph.stations[sid]
-        cx, cy, _, _, _ = station_marker_box(graph, NFCORE_THEME, st, offsets)
+        cx, cy, _, _, _ = station_marker_box(graph, NFCORE_DARK_THEME, st, offsets)
         assert entry["x"] == round(cx, 1)
         assert entry["y"] == round(cy, 1)
-        assert entry["r"] == round(NFCORE_THEME.station_radius, 1)
+        assert entry["r"] == round(NFCORE_DARK_THEME.station_radius, 1)
         assert entry["groups"] == graph.station_lines(sid)
         assert entry["patterns"] == graph.process_mapping.get(sid, [])
 
@@ -187,7 +187,7 @@ def test_manifest_arrays_follow_graph_declaration_order() -> None:
     ordering regression point straight at the offending derivation.
     """
     graph = parse_and_layout(MAPPED_TEXT)
-    manifest = read_manifest(render_svg(graph, NFCORE_THEME))
+    manifest = read_manifest(render_svg(graph, NFCORE_DARK_THEME))
 
     expected_nodes = [
         sid for sid, st in graph.stations.items() if not st.is_port and not st.is_hidden
@@ -215,7 +215,7 @@ def test_coordinate_space_is_viewbox(mapped_svg: str) -> None:
 def test_matcher_mirrors_live_server() -> None:
     """match_node_ids reproduces stations_for_process exactly."""
     graph = parse_and_layout(MAPPED_TEXT)
-    manifest = read_manifest(render_svg(graph, NFCORE_THEME))
+    manifest = read_manifest(render_svg(graph, NFCORE_DARK_THEME))
     process_names = [
         "NFCORE:PIPE:SAMPLESHEET",
         "TRIMGALORE",
@@ -231,8 +231,8 @@ def test_matcher_mirrors_live_server() -> None:
 
 def test_manifest_is_deterministic() -> None:
     graph = parse_and_layout(MAPPED_TEXT)
-    a = render_svg(graph, NFCORE_THEME)
-    b = render_svg(graph, NFCORE_THEME)
+    a = render_svg(graph, NFCORE_DARK_THEME)
+    b = render_svg(graph, NFCORE_DARK_THEME)
     assert read_manifest(a) == read_manifest(b)
 
 
@@ -246,7 +246,7 @@ def test_cdata_survives_bracket_sequence() -> None:
         "    b[B]\n"
         "    a -->|x| b\n"
     )
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     ET.fromstring(svg)  # must be well-formed XML
     parsed = read_manifest(svg)
     a = next(n for n in parsed["nodes"] if n["id"] == "a")
@@ -258,7 +258,7 @@ def test_corpus_manifest_roundtrips(fixture_id, path, is_nextflow) -> None:
     """Every gallery/topology fixture renders an SVG whose manifest reads back
     and whose node ids all appear as data-node-id handles."""
     graph = compute_corpus_layout(path, is_nextflow)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     manifest = read_manifest(svg)
     assert manifest is not None
     jsonschema.validate(manifest, manifest_schema())

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -15,7 +15,7 @@ from nf_metro.render.legend import (
     marker_stroke_color,
 )
 from nf_metro.render.svg import render_svg
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 _BASE = (
     "%%metro line: a | Line A | #4CAF50\n"
@@ -102,10 +102,15 @@ def test_marker_legend_default_empty():
 
 
 def test_marker_fill_color_keywords_and_literal():
-    assert marker_fill_color("solid", NFCORE_THEME) == NFCORE_THEME.station_fill
-    assert marker_fill_color("#abcdef", NFCORE_THEME) == "#abcdef"
+    assert (
+        marker_fill_color("solid", NFCORE_DARK_THEME) == NFCORE_DARK_THEME.station_fill
+    )
+    assert marker_fill_color("#abcdef", NFCORE_DARK_THEME) == "#abcdef"
     # open falls back to the background colour on the dark theme.
-    assert marker_fill_color("open", NFCORE_THEME) == NFCORE_THEME.background_color
+    assert (
+        marker_fill_color("open", NFCORE_DARK_THEME)
+        == NFCORE_DARK_THEME.background_color
+    )
 
 
 # --- Pill shape --------------------------------------------------------------
@@ -128,7 +133,7 @@ def test_pill_marker_is_capsule_elongated_along_the_line():
     # rounded rect (rx == r) wider than it is tall, elongated along the line.
     g = _parse("%%metro marker: n2 | pill, #4CAF50\n")
     compute_layout(g)
-    svg = render_svg(g, NFCORE_THEME)
+    svg = render_svg(g, NFCORE_DARK_THEME)
     root = ET.fromstring(svg)
     ns = "{http://www.w3.org/2000/svg}"
     pills = [
@@ -137,7 +142,7 @@ def test_pill_marker_is_capsule_elongated_along_the_line():
         if el.get("data-station-id") == "n2" and el.get("fill") == "#4CAF50"
     ]
     assert pills, "expected a pill marker rect"
-    r = NFCORE_THEME.station_radius
+    r = NFCORE_DARK_THEME.station_radius
     for el in pills:
         w, h = float(el.get("width")), float(el.get("height"))
         assert float(el.get("rx")) == r
@@ -161,14 +166,14 @@ def test_pill_marker_grows_across_multiple_tracks():
     )
     g = parse_metro_mermaid(multi)
     compute_layout(g)
-    svg = render_svg(g, NFCORE_THEME)
+    svg = render_svg(g, NFCORE_DARK_THEME)
     root = ET.fromstring(svg)
     ns = "{http://www.w3.org/2000/svg}"
     pills = [el for el in root.iter(f"{ns}rect") if el.get("data-station-id") == "n2"]
     assert pills, "expected a pill marker rect"
     # Two tracks => taller than a single-track pill (> 2r).
     assert any(
-        float(el.get("height")) > 2 * NFCORE_THEME.station_radius for el in pills
+        float(el.get("height")) > 2 * NFCORE_DARK_THEME.station_radius for el in pills
     )
 
 
@@ -181,7 +186,7 @@ def test_marker_station_renders_valid_svg():
         "%%metro marker_legend: square, #4CAF50 | Accelerated\n"
     )
     compute_layout(g)
-    svg = render_svg(g, NFCORE_THEME)
+    svg = render_svg(g, NFCORE_DARK_THEME)
     ET.fromstring(svg)  # well-formed
     assert "#4CAF50" in svg
     assert "Accelerated" in svg
@@ -196,7 +201,9 @@ def test_no_marker_directives_byte_identical():
     g_with.stations["n2"].marker = None
     compute_layout(g_plain)
     compute_layout(g_with)
-    assert render_svg(g_plain, NFCORE_THEME) == render_svg(g_with, NFCORE_THEME)
+    assert render_svg(g_plain, NFCORE_DARK_THEME) == render_svg(
+        g_with, NFCORE_DARK_THEME
+    )
 
 
 # --- Marker outline visibility ----------------------------------------------
@@ -205,14 +212,14 @@ def test_no_marker_directives_byte_identical():
 def test_marker_stroke_color_uses_theme_marker_stroke():
     # The dark theme sets a dedicated light marker outline so dark-filled
     # markers stay visible against the background.
-    assert NFCORE_THEME.marker_stroke
-    assert marker_stroke_color(NFCORE_THEME) == NFCORE_THEME.marker_stroke
-    assert marker_stroke_color(NFCORE_THEME) != NFCORE_THEME.station_stroke
+    assert NFCORE_DARK_THEME.marker_stroke
+    assert marker_stroke_color(NFCORE_DARK_THEME) == NFCORE_DARK_THEME.marker_stroke
+    assert marker_stroke_color(NFCORE_DARK_THEME) != NFCORE_DARK_THEME.station_stroke
 
 
 def test_marker_stroke_color_falls_back_to_station_stroke():
     # A theme that does not set marker_stroke inherits station_stroke.
-    theme = replace(NFCORE_THEME, marker_stroke="")
+    theme = replace(NFCORE_DARK_THEME, marker_stroke="")
     assert marker_stroke_color(theme) == theme.station_stroke
 
 
@@ -221,7 +228,7 @@ def test_dark_marker_glyph_has_light_outline():
     # not the dark station stroke, so it stands out on the dark background.
     g = _parse("%%metro marker: n2 | square, #1f4e79\n")
     compute_layout(g)
-    svg = render_svg(g, NFCORE_THEME)
+    svg = render_svg(g, NFCORE_DARK_THEME)
     root = ET.fromstring(svg)
     ns = "{http://www.w3.org/2000/svg}"
     marker_rects = [
@@ -231,8 +238,8 @@ def test_dark_marker_glyph_has_light_outline():
     ]
     assert marker_rects, "expected a dark-filled marker rect"
     for el in marker_rects:
-        assert el.get("stroke") == NFCORE_THEME.marker_stroke
-        assert el.get("stroke") != NFCORE_THEME.station_stroke
+        assert el.get("stroke") == NFCORE_DARK_THEME.marker_stroke
+        assert el.get("stroke") != NFCORE_DARK_THEME.station_stroke
 
 
 def test_marker_legend_swatch_has_light_outline():
@@ -240,10 +247,10 @@ def test_marker_legend_swatch_has_light_outline():
     # outline so the legend matches the map.
     g = _parse("%%metro marker_legend: square, #1f4e79 | Accelerated\n")
     compute_layout(g)
-    svg = render_svg(g, NFCORE_THEME)
+    svg = render_svg(g, NFCORE_DARK_THEME)
     root = ET.fromstring(svg)
     ns = "{http://www.w3.org/2000/svg}"
     swatches = [el for el in root.iter(f"{ns}rect") if el.get("fill") == "#1f4e79"]
     assert swatches, "expected a dark-filled legend swatch"
     for el in swatches:
-        assert el.get("stroke") == NFCORE_THEME.marker_stroke
+        assert el.get("stroke") == NFCORE_DARK_THEME.marker_stroke

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -563,7 +563,7 @@ def test_empty_section_removed_render():
     """
     from nf_metro.layout.engine import compute_layout
     from nf_metro.render.svg import render_svg
-    from nf_metro.themes import NFCORE_THEME
+    from nf_metro.themes import NFCORE_DARK_THEME
 
     text = (
         "%%metro line: dna | DNA | #004b86\n"
@@ -584,7 +584,7 @@ def test_empty_section_removed_render():
         graph = parse_metro_mermaid(text)
 
     compute_layout(graph)
-    svg_str = render_svg(graph, NFCORE_THEME)
+    svg_str = render_svg(graph, NFCORE_DARK_THEME)
 
     # All station labels should appear in the SVG output
     assert "cat" in svg_str

--- a/tests/test_rail_offtrack_io.py
+++ b/tests/test_rail_offtrack_io.py
@@ -20,7 +20,7 @@ from nf_metro.layout.labels import find_label_overlaps, place_labels
 from nf_metro.layout.routing import compute_station_offsets
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render.svg import render_svg
-from nf_metro.themes.nfcore import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES = REPO_ROOT / "examples"
@@ -73,12 +73,12 @@ def test_offtrack_file_terminus_has_buffer_stop_nub(stem: str, term_id: str) -> 
     graph = _laid_out(stem)
     station = graph.stations[term_id]
     assert station.off_track and station.is_blank_terminus
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     nubs = _station_rects(svg, term_id)
     assert nubs, f"{stem}: off-track file terminus {term_id!r} drew no buffer-stop nub"
     # The nub seats at the rail-side stub end (the station coordinate), not up at
     # the icon.
-    r = NFCORE_THEME.station_radius
+    r = NFCORE_DARK_THEME.station_radius
     assert any(
         abs(float(n.get("y")) + float(n.get("height")) / 2 - station.y) <= r + 1.0
         for n in nubs
@@ -89,7 +89,7 @@ def test_offtrack_file_terminus_nub_clears_caption() -> None:
     """The buffer-stop nub must not sit on the under-icon caption."""
     stem = "rail_offtrack_io"
     graph = _laid_out(stem)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     root = ET.fromstring(svg)
     captions = {el.text: el for el in root.iter(f"{NS}text") if el.text in ("Targets",)}
     assert "Targets" in captions, "expected the 'Targets' caption to render"
@@ -109,7 +109,7 @@ def test_plain_offtrack_node_renders_marker(node_id: str) -> None:
     graph = _laid_out("rail_offtrack_plain_io")
     station = graph.stations[node_id]
     assert station.off_track and not station.is_blank_terminus
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     markers = _station_rects(svg, node_id)
     assert markers, (
         f"plain off-track node {node_id!r} rendered no marker (bare line end)"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -21,7 +21,7 @@ from nf_metro.render.svg import (
 )
 from nf_metro.themes import (
     LIGHT_THEME,
-    NFCORE_THEME,
+    NFCORE_DARK_THEME,
     SEQERA_DARK_THEME,
     SEQERA_LIGHT_THEME,
 )
@@ -37,7 +37,7 @@ def _render_simple():
         "    a -->|main| b\n"
     )
     compute_layout(graph)
-    return render_svg(graph, NFCORE_THEME)
+    return render_svg(graph, NFCORE_DARK_THEME)
 
 
 def test_render_produces_valid_svg():
@@ -71,7 +71,7 @@ def test_render_caption_appears_in_svg():
         "    a[Input] -->|main| b[Output]\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "Example attribution text" in svg
 
 
@@ -91,7 +91,7 @@ def test_label_angle_emits_rotate_transform():
         "    a -->|main| b\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "rotate(45" in svg
 
 
@@ -102,7 +102,7 @@ def test_label_angle_default_no_rotate():
 
 def test_render_nfcore_theme_background():
     svg = _render_simple()
-    assert NFCORE_THEME.background_color in svg
+    assert NFCORE_DARK_THEME.background_color in svg
 
 
 def test_render_light_theme():
@@ -144,7 +144,7 @@ def test_render_dashed_line_has_dasharray():
         "    a -->|main| b\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert 'stroke-dasharray="8,4"' in svg or "stroke-dasharray='8,4'" in svg
 
 
@@ -159,7 +159,7 @@ def test_render_dotted_line_has_dasharray():
         "    a -->|main| b\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert 'stroke-dasharray="2,4"' in svg or "stroke-dasharray='2,4'" in svg
 
 
@@ -174,13 +174,13 @@ def test_render_solid_line_no_dasharray():
         "    a -->|main| b\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "stroke-dasharray" not in svg
 
 
 def test_render_empty_graph():
     graph = parse_metro_mermaid("graph LR\n")
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "svg" in svg
 
 
@@ -201,7 +201,7 @@ def test_legend_min_height_enlarges_legend():
         "    a -->|main| b\n"
     )
     graph_default = parse_metro_mermaid(base_text)
-    _, h_default = compute_legend_dimensions(graph_default, NFCORE_THEME)
+    _, h_default = compute_legend_dimensions(graph_default, NFCORE_DARK_THEME)
 
     min_h_text = (
         "%%metro legend_min_height: 120\n"
@@ -211,7 +211,7 @@ def test_legend_min_height_enlarges_legend():
         "    a -->|main| b\n"
     )
     graph_min = parse_metro_mermaid(min_h_text)
-    _, h_min = compute_legend_dimensions(graph_min, NFCORE_THEME)
+    _, h_min = compute_legend_dimensions(graph_min, NFCORE_DARK_THEME)
 
     assert h_min > h_default
     # content_height should be at least the minimum
@@ -233,10 +233,10 @@ def test_logo_scale_enlarges_bundled_logo():
     logo = (320.0, 120.0)  # original (w, h) aspect carrier
 
     g1 = parse_metro_mermaid(base)
-    w1, h1 = compute_legend_dimensions(g1, NFCORE_THEME, logo_size=logo)
+    w1, h1 = compute_legend_dimensions(g1, NFCORE_DARK_THEME, logo_size=logo)
 
     g2 = parse_metro_mermaid("%%metro logo_scale: 2.0\n" + base)
-    w2, h2 = compute_legend_dimensions(g2, NFCORE_THEME, logo_size=logo)
+    w2, h2 = compute_legend_dimensions(g2, NFCORE_DARK_THEME, logo_size=logo)
 
     # A larger logo widens the block and, once it exceeds the text block,
     # grows the legend height to contain it.
@@ -256,7 +256,7 @@ def test_logo_scale_default_no_change():
     g = parse_metro_mermaid(base)
     assert g.logo_scale == 1.0
     # Should not raise and should produce a positive-size legend.
-    w, h = compute_legend_dimensions(g, NFCORE_THEME, logo_size=logo)
+    w, h = compute_legend_dimensions(g, NFCORE_DARK_THEME, logo_size=logo)
     assert w > 0 and h > 0
 
 
@@ -271,11 +271,11 @@ def test_legend_logo_gap_widens_block():
     logo = (320.0, 120.0)
 
     g1 = parse_metro_mermaid(base)
-    w1, _ = compute_legend_dimensions(g1, NFCORE_THEME, logo_size=logo)
+    w1, _ = compute_legend_dimensions(g1, NFCORE_DARK_THEME, logo_size=logo)
 
     gap = LOGO_GAP + 30.0
     g2 = parse_metro_mermaid(f"%%metro legend_logo_gap: {gap}\n" + base)
-    w2, _ = compute_legend_dimensions(g2, NFCORE_THEME, logo_size=logo)
+    w2, _ = compute_legend_dimensions(g2, NFCORE_DARK_THEME, logo_size=logo)
 
     assert w2 == pytest.approx(w1 + 30.0)
 
@@ -310,16 +310,16 @@ def test_font_scale_multiplies_all_text_sizes():
     """`font_scale: N` renders every text class at N times the default size."""
     scale = 2.0
     g1 = _load_font_scale_fixture()
-    svg1 = render_svg(g1, NFCORE_THEME)
+    svg1 = render_svg(g1, NFCORE_DARK_THEME)
     g2 = _load_font_scale_fixture(scale)
-    svg2 = render_svg(g2, NFCORE_THEME)
+    svg2 = render_svg(g2, NFCORE_DARK_THEME)
 
     for size in (
-        NFCORE_THEME.label_font_size,
-        NFCORE_THEME.title_font_size,
-        NFCORE_THEME.section_label_font_size,
-        NFCORE_THEME.legend_font_size,
-        NFCORE_THEME.terminus_font_size,
+        NFCORE_DARK_THEME.label_font_size,
+        NFCORE_DARK_THEME.title_font_size,
+        NFCORE_DARK_THEME.section_label_font_size,
+        NFCORE_DARK_THEME.legend_font_size,
+        NFCORE_DARK_THEME.terminus_font_size,
     ):
         assert size in _font_sizes(svg1)
         assert size * scale in _font_sizes(svg2)
@@ -460,9 +460,9 @@ def test_font_scale_default_is_noop():
     """Without `font_scale`, the graph and render match the unscaled default."""
     g = _load_font_scale_fixture()
     assert g.font_scale == 1.0
-    svg_default = render_svg(g, NFCORE_THEME)
+    svg_default = render_svg(g, NFCORE_DARK_THEME)
     g_explicit = _load_font_scale_fixture(1.0)
-    svg_explicit = render_svg(g_explicit, NFCORE_THEME)
+    svg_explicit = render_svg(g_explicit, NFCORE_DARK_THEME)
     assert svg_default == svg_explicit
 
 
@@ -481,7 +481,7 @@ def test_render_file_size():
         "    end\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     # Should be well under 50KB for a small graph
     assert len(svg) < 50000
 
@@ -506,7 +506,7 @@ def test_render_first_class_sections():
         "    b -->|main| c\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "Processing" in svg
     assert "Output" in svg
     assert "Input" in svg
@@ -530,7 +530,7 @@ def test_render_sections_no_port_labels():
         "    a -->|main| b\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     # Port IDs should not appear in the SVG text
     for port_id in graph.ports:
         assert port_id not in svg, f"Port {port_id} should not appear in SVG"
@@ -547,7 +547,7 @@ def test_render_multiline_labels():
         "    a -->|main| b\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     # Both lines should appear in the SVG as separate tspan elements
     assert "Line One" in svg
     assert "Line Two" in svg
@@ -568,7 +568,7 @@ def test_render_rnaseq_sections_example():
     text = (examples / "rnaseq_sections.mmd").read_text()
     graph = parse_metro_mermaid(text)
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     # Title text is replaced by embedded logo, so check section labels
     assert "Pre-processing" in svg
     root = ET.fromstring(svg)
@@ -591,7 +591,7 @@ def test_render_single_file_icon():
         "    end\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "FASTQ" in svg
     root = ET.fromstring(svg)
     assert root.tag.endswith("svg") or "svg" in root.tag
@@ -610,7 +610,7 @@ def test_render_multiple_file_icons():
         "    end\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "FASTQ" in svg
     assert "BAM" in svg
     root = ET.fromstring(svg)
@@ -630,7 +630,7 @@ def test_render_file_icon_with_name_caption():
         "    end\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     # Caption name and inner type label should both appear
     assert "Samples" in svg
     assert "CSV" in svg
@@ -650,7 +650,7 @@ def test_render_icon_caption_with_linebreak():
     )
     compute_layout(graph)
 
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     root = ET.fromstring(svg)
     tspan_values = [
         element.text for element in root.iter() if element.tag.endswith("tspan")
@@ -697,15 +697,15 @@ def test_multiline_icon_caption_fits_render_obstacle(direction):
     centers = _terminus_icon_centers_for(
         station,
         graph,
-        NFCORE_THEME,
+        NFCORE_DARK_THEME,
         min(line_offsets, default=0.0),
         max(line_offsets, default=0.0),
     )
-    obstacle = _icon_obstacles_by_station(graph, NFCORE_THEME, offsets)[station.id]
-    caption_height = 2 * NFCORE_THEME.label_font_size * ICON_NAME_FONT_SCALE
+    obstacle = _icon_obstacles_by_station(graph, NFCORE_DARK_THEME, offsets)[station.id]
+    caption_height = 2 * NFCORE_DARK_THEME.label_font_size * ICON_NAME_FONT_SCALE
     expected_bottom = (
         max(cy for _, cy in centers)
-        + NFCORE_THEME.terminus_height / 2
+        + NFCORE_DARK_THEME.terminus_height / 2
         + ICON_NAME_GAP
         + caption_height
         + ICON_CLEARANCE_MARGIN
@@ -735,11 +735,14 @@ def test_vertical_icon_stack_reserves_multiline_caption(direction):
     )
     compute_layout(graph)
     centers = _terminus_icon_centers_for(
-        graph.stations["source"], graph, NFCORE_THEME, 0.0, 0.0
+        graph.stations["source"], graph, NFCORE_DARK_THEME, 0.0, 0.0
     )
-    caption_height = 2 * NFCORE_THEME.label_font_size * ICON_NAME_FONT_SCALE
+    caption_height = 2 * NFCORE_DARK_THEME.label_font_size * ICON_NAME_FONT_SCALE
     expected_step = (
-        NFCORE_THEME.terminus_height + ICON_INTER_GAP + ICON_NAME_GAP + caption_height
+        NFCORE_DARK_THEME.terminus_height
+        + ICON_INTER_GAP
+        + ICON_NAME_GAP
+        + caption_height
     )
 
     assert abs(centers[1][1] - centers[0][1]) == pytest.approx(expected_step)
@@ -752,7 +755,7 @@ def test_render_file_icon_with_outgoing_edge():
     )
     graph = parse_metro_mermaid(fixture.read_text())
     compute_layout(graph)
-    root = ET.fromstring(render_svg(graph, NFCORE_THEME))
+    root = ET.fromstring(render_svg(graph, NFCORE_DARK_THEME))
     ns = {"svg": "http://www.w3.org/2000/svg"}
     visible_text = [
         "".join(element.itertext()) for element in root.findall(".//svg:text", ns)
@@ -782,8 +785,8 @@ def test_caption_font_smaller_than_label_font():
         "    end\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
-    label_size = NFCORE_THEME.label_font_size
+    svg = render_svg(graph, NFCORE_DARK_THEME)
+    label_size = NFCORE_DARK_THEME.label_font_size
     # The caption text must reference a font-size strictly smaller than
     # the theme label_font_size (60% of it, per ICON_NAME_FONT_SCALE).
     import re
@@ -809,7 +812,7 @@ def test_render_file_icon_no_name_no_caption():
         "    end\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     # The station has no label and there's no caption directive, so the only
     # text inside the terminus block should be the type chip.
     assert "FASTQ" in svg
@@ -826,7 +829,7 @@ def test_wide_file_icon_label_wraps_within_icon_width():
     fixture = Path(__file__).parent / "fixtures" / "icon_caption_wrap.mmd"
     graph = parse_metro_mermaid(fixture.read_text())
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
 
     pieces = re.findall(r'font-size="([0-9.]+)"[^>]*>([^<]*BAM[^<]*|CRAM)</text>', svg)
     assert pieces, "wrapped BAM/CRAM label pieces not found in SVG"
@@ -834,7 +837,7 @@ def test_wide_file_icon_label_wraps_within_icon_width():
         "label must wrap rather than render as a single over-wide line"
     )
 
-    max_width = NFCORE_THEME.terminus_width - 2 * ICON_LABEL_CLEARANCE
+    max_width = NFCORE_DARK_THEME.terminus_width - 2 * ICON_LABEL_CLEARANCE
     tolerance = 1.0
     for font_size, text in pieces:
         line_width = DEFAULT_TEXT_METRICS.reserve_width(
@@ -866,7 +869,7 @@ def test_render_multi_icon_fixture():
     text = (examples / "05b_multi_icons.mmd").read_text()
     graph = parse_metro_mermaid(text)
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     # All icon labels should be present
     assert "FASTQ" in svg
     assert "BAM" in svg
@@ -890,7 +893,7 @@ def test_render_files_icon():
         "    end\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "FASTQ" in svg
     root = ET.fromstring(svg)
     assert root.tag.endswith("svg") or "svg" in root.tag
@@ -909,7 +912,7 @@ def test_render_folder_icon():
         "    end\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "Results" in svg
     root = ET.fromstring(svg)
     assert root.tag.endswith("svg") or "svg" in root.tag
@@ -934,7 +937,7 @@ def test_render_mixed_icon_types():
         "    end\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "FASTA" in svg
     assert "FASTQ" in svg
     assert "Results" in svg
@@ -959,7 +962,7 @@ def test_file_icon_banner_option():
     # The caption (third field) is still parsed alongside the banner option.
     assert station.terminus_names == ["Alignments"]
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     from nf_metro.render.constants import ICON_BANNER_FILL
 
     assert ICON_BANNER_FILL in svg
@@ -996,7 +999,7 @@ def test_render_icon_type_guide_fixtures():
         text = fpath.read_text()
         graph = parse_metro_mermaid(text)
         compute_layout(graph)
-        svg = render_svg(graph, NFCORE_THEME)
+        svg = render_svg(graph, NFCORE_DARK_THEME)
         root = ET.fromstring(svg)
         assert root.tag.endswith("svg") or "svg" in root.tag
 
@@ -1093,9 +1096,9 @@ def test_stacked_files_icon_back_page_does_not_crowd_marker(direction, role):
     is_source = role == "source"
 
     front_cx, front_cy = _terminus_icon_centers_for(
-        station, graph, NFCORE_THEME, 0.0, 0.0
+        station, graph, NFCORE_DARK_THEME, 0.0, 0.0
     )[0]
-    off = NFCORE_THEME.terminus_width * FILES_ICON_OFFSET_RATIO
+    off = NFCORE_DARK_THEME.terminus_width * FILES_ICON_OFFSET_RATIO
     flow_sign = _terminus_icon_flow_sign(direction, is_source)
     is_vertical_flow = lanes_run_along_x(direction)
 
@@ -1145,7 +1148,7 @@ def test_render_tb_section_file_icon_below_station():
     assert abs(icon_cx - station.x) < 1e-6
     assert icon_cy > station.y
     # And the render still succeeds and carries the icon label.
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     assert "HTML" in svg
     root = ET.fromstring(svg)
     assert root.tag.endswith("svg") or "svg" in root.tag
@@ -1168,7 +1171,7 @@ def test_render_tb_terminus_pill_is_horizontal():
         "    end\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     # The terminus nub <rect> carries data-station-id="out"; in a TB section
     # it must be wider than tall (lines arrive vertically into it).
     m = re.search(r'<rect\b[^>]*data-station-id="out"[^>]*/?>', svg)
@@ -1195,7 +1198,7 @@ def test_render_group_label_caption_and_underline():
 
     base_graph = parse_metro_mermaid(base_src)
     compute_layout(base_graph)
-    base_svg = render_svg(base_graph, NFCORE_THEME)
+    base_svg = render_svg(base_graph, NFCORE_DARK_THEME)
 
     grouped_graph = parse_metro_mermaid(grouped_src)
     compute_layout(grouped_graph)
@@ -1204,7 +1207,7 @@ def test_render_group_label_caption_and_underline():
         sid: (st.x, st.y) for sid, st in base_graph.stations.items()
     }
 
-    grouped_svg = render_svg(grouped_graph, NFCORE_THEME)
+    grouped_svg = render_svg(grouped_graph, NFCORE_DARK_THEME)
     assert "Family" in grouped_svg
     assert "nf-metro-group-label" in grouped_svg
     assert "nf-metro-group-underline" in grouped_svg
@@ -1245,7 +1248,7 @@ def test_render_group_band_stays_inside_section_box():
     )
     graph = parse_metro_mermaid(src)
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
 
     section_bottom = _section_box_bottoms(svg)["s"]
 
@@ -1310,14 +1313,14 @@ def test_standalone_nodes_render_as_unlinked_labels():
         assert sec.bbox_x <= st.x <= sec.bbox_x + sec.bbox_w
         assert sec.bbox_y <= st.y <= sec.bbox_y + sec.bbox_h
 
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     for t in standalone:
         assert t in svg
 
 
 def test_label_halo_color_resolves_to_opaque_background():
-    color = _label_halo_color(replace(NFCORE_THEME, label_halo_color=""))
-    assert color == NFCORE_THEME.background_color
+    color = _label_halo_color(replace(NFCORE_DARK_THEME, label_halo_color=""))
+    assert color == NFCORE_DARK_THEME.background_color
 
 
 def test_label_halo_color_resolves_to_white_on_transparent_theme():
@@ -1326,16 +1329,18 @@ def test_label_halo_color_resolves_to_white_on_transparent_theme():
 
 
 def test_label_halo_color_honours_explicit_colour():
-    color = _label_halo_color(replace(NFCORE_THEME, label_halo_color="#123456"))
+    color = _label_halo_color(replace(NFCORE_DARK_THEME, label_halo_color="#123456"))
     assert color == "#123456"
 
 
 def test_label_halo_disabled_by_zero_width():
-    assert _label_halo_color(replace(NFCORE_THEME, label_halo_width=0.0)) is None
+    assert _label_halo_color(replace(NFCORE_DARK_THEME, label_halo_width=0.0)) is None
 
 
 def test_label_halo_disabled_by_none_colour():
-    assert _label_halo_color(replace(NFCORE_THEME, label_halo_color="none")) is None
+    assert (
+        _label_halo_color(replace(NFCORE_DARK_THEME, label_halo_color="none")) is None
+    )
 
 
 def test_label_halo_emits_aria_hidden_backing_copy():
@@ -1347,7 +1352,7 @@ def test_label_halo_emits_aria_hidden_backing_copy():
         "    a -->|main| b\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
 
     root = ET.fromstring(svg)
     ns = "{http://www.w3.org/2000/svg}"
@@ -1361,9 +1366,9 @@ def test_label_halo_emits_aria_hidden_backing_copy():
 
     # The halo is a stroked knockout: it must paint the resolved halo colour on
     # both fill and stroke at the theme width, and sit under the visible glyph.
-    resolved = _label_halo_color(NFCORE_THEME)
+    resolved = _label_halo_color(NFCORE_DARK_THEME)
     assert halo[0].get("stroke") == halo[0].get("fill") == resolved
-    assert float(halo[0].get("stroke-width")) == NFCORE_THEME.label_halo_width
+    assert float(halo[0].get("stroke-width")) == NFCORE_DARK_THEME.label_halo_width
     assert texts.index(halo[0]) < texts.index(fill[0]), (
         "halo must precede the visible label in document order so it draws under it"
     )
@@ -1378,7 +1383,7 @@ def test_label_halo_suppressed_when_disabled():
         "    a -->|main| b\n"
     )
     compute_layout(graph)
-    svg = render_svg(graph, replace(NFCORE_THEME, label_halo_width=0.0))
+    svg = render_svg(graph, replace(NFCORE_DARK_THEME, label_halo_width=0.0))
 
     root = ET.fromstring(svg)
     ns = "{http://www.w3.org/2000/svg}"
@@ -1405,14 +1410,14 @@ def _graph_for_responsive():
 
 
 def test_responsive_render_omits_fixed_dimensions():
-    svg = render_svg(_graph_for_responsive(), NFCORE_THEME, responsive=True)
+    svg = render_svg(_graph_for_responsive(), NFCORE_DARK_THEME, responsive=True)
     root = ET.fromstring(svg)
     assert root.get("width") is None, "responsive SVG must not carry a fixed width"
     assert root.get("height") is None, "responsive SVG must not carry a fixed height"
 
 
 def test_responsive_render_has_viewbox_and_aspect_ratio():
-    svg = render_svg(_graph_for_responsive(), NFCORE_THEME, responsive=True)
+    svg = render_svg(_graph_for_responsive(), NFCORE_DARK_THEME, responsive=True)
     root = ET.fromstring(svg)
     assert root.get("viewBox") is not None, "responsive SVG must have a viewBox"
     assert root.get("preserveAspectRatio") == "xMinYMin meet", (
@@ -1421,7 +1426,7 @@ def test_responsive_render_has_viewbox_and_aspect_ratio():
 
 
 def test_default_render_retains_fixed_dimensions():
-    svg = render_svg(_graph_for_responsive(), NFCORE_THEME)
+    svg = render_svg(_graph_for_responsive(), NFCORE_DARK_THEME)
     root = ET.fromstring(svg)
     assert root.get("width") is not None, "default SVG must carry a fixed width"
     assert root.get("height") is not None, "default SVG must carry a fixed height"

--- a/tests/test_svg_namespace.py
+++ b/tests/test_svg_namespace.py
@@ -5,7 +5,7 @@ import re
 from nf_metro.layout.engine import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render.svg import render_svg
-from nf_metro.themes import LIGHT_THEME, NFCORE_THEME
+from nf_metro.themes import LIGHT_THEME, NFCORE_DARK_THEME
 
 _MMD = (
     "%%metro title: Test\n"
@@ -39,8 +39,8 @@ def test_dark_mode_css_present_for_transparent_theme_by_default():
 
 
 def test_dark_mode_css_absent_for_opaque_theme():
-    """NFCORE_THEME (opaque background) does not inject the dark-mode block."""
-    svg = render_svg(_make_graph(), NFCORE_THEME)
+    """NFCORE_DARK_THEME (opaque background) does not inject the dark-mode block."""
+    svg = render_svg(_make_graph(), NFCORE_DARK_THEME)
     assert "prefers-color-scheme" not in svg
 
 

--- a/tests/test_svg_paths.py
+++ b/tests/test_svg_paths.py
@@ -24,7 +24,7 @@ from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render import build_render_plan, emit_render_plan
 from nf_metro.render.animate import _points_to_svg_path
 from nf_metro.render.svg import _curve_tangents, apply_route_offsets, render_svg
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 TOPOLOGIES_DIR = EXAMPLES_DIR / "topologies"
@@ -82,7 +82,7 @@ def _layout_and_route(mmd_text: str) -> tuple:
     compute_layout(graph)
     offsets = compute_station_offsets(graph)
     routes = route_edges(graph, station_offsets=offsets)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     return graph, routes, offsets, svg
 
 
@@ -413,7 +413,7 @@ class TestQCountMatchesCorners:
         """
         graph = parse_metro_mermaid(mmd_text)
         compute_layout(graph)
-        plan = build_render_plan(graph, NFCORE_THEME)
+        plan = build_render_plan(graph, NFCORE_DARK_THEME)
         expected_corners = sum(
             max(0, len(points) - 2) for points in plan.route_polylines
         )

--- a/tests/test_tall_anchor_stack.py
+++ b/tests/test_tall_anchor_stack.py
@@ -21,7 +21,7 @@ from nf_metro.layout.phases.guards import (
 )
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render.svg import render_svg
-from nf_metro.themes import NFCORE_THEME
+from nf_metro.themes import NFCORE_DARK_THEME
 
 EXAMPLES = Path(__file__).parent.parent / "examples"
 
@@ -49,7 +49,7 @@ def _section_columns(graph) -> set[int]:
 def _render_width(text: str) -> int:
     graph = parse_metro_mermaid(text)
     compute_layout(graph)
-    svg = render_svg(graph, NFCORE_THEME)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
     match = re.search(r'width="(\d+)"', svg)
     assert match is not None
     return int(match.group(1))


### PR DESCRIPTION
## How themes resolve

Brand (`nfcore`, `seqera`) and display mode (`light`, `dark`) are orthogonal axes. `THEME_MODES` maps a brand to its `{light, dark}` pair; `THEMES` is the flat by-name registry the CLI `--theme` and `%%metro style:` look up, and its bare-brand keys resolve to that brand at `DEFAULT_MODE` (`"dark"`), so `--theme nfcore` with no `--mode` renders the nfcore dark palette as the baked default while still emitting both palettes through `light-dark()` and adapting to the viewer's `color-scheme`. `light` is not a mode of a brand: `LIGHT_THEME` is a brand-less transparent embed theme (`background_color="none"`, larger type, 6px stations) that differs from `NFCORE_LIGHT_THEME` in eleven fields, so `mode_pair()` returns `None` for it and it renders a single palette. The Python constants `NFCORE_THEME` and `SEQERA_THEME` mirrored nothing CLI-visible: they were bare-brand aliases for the dark variants, used only as a convenient concrete theme in ~25 test modules (`SEQERA_THEME` had no consumer at all), and their name quietly encoded "the default mode is dark" in every one of those call sites.

`dark` as a `%%metro style:` value is still load-bearing and stays: it is `MetroGraph.style`'s default, so every map without a style directive resolves through the `dark -> nfcore` alias. It is not a `--theme` value (that option is a `Choice` over `THEMES`, which has no `dark` key).

## What changed

- Removed `NFCORE_THEME` and `SEQERA_THEME`. Test call sites now use `NFCORE_DARK_THEME`, which names the palette they render with and cannot drift if `DEFAULT_MODE` changes; `__all__` follows.
- Three test modules that reached into `nf_metro.themes.nfcore` now import from the `nf_metro.themes` package like the other sixteen.
- `serve` and `serve-multi` took `--theme` as free text and advertised two of the seven names. Both now use the same `click.Choice(list(THEMES))` as `render`, so the help lists every accepted name; `serve` no longer falls back to nfcore on an unknown name and `serve-multi`'s hand-rolled membership check is gone (click reports the same set, as a usage error).
- `docs/dev/render.md`: `Theme` is a keyword-only dataclass, not a frozen one.

## Byte-identical CLI proof

`examples/rnaseq_sections.mmd` rendered on this branch and on the branch base (`1a5c9b60`, a throwaway detached worktree) for all seven `--theme` values bare, and again with `--mode light` and `--mode dark`: 21 md5 pairs, all identical. `render --help` is unchanged verbatim; `serve`/`serve-multi --help` change only in the `--theme` row.

## Left alone

- `docs/cli.md`: the `serve` and `serve-multi` `--theme` rows now list the same seven choices as `render --theme`.
- `LIGHT_THEME` carries `mode="dark"` from the dataclass default despite being the light embed theme, which is what `--theme light --debug` reads for its debug palette and what dual-`%%metro logo:` selection reads in non-adaptive renders. Correcting it changes rendered output, so it is not part of a behaviour-neutral pass.
- `MetroGraph.style` defaults to the literal `"dark"` (a mode name standing in for a brand) and is surfaced verbatim by `introspect`, so retiring the alias by defaulting it to `"nfcore"` would change introspection output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
