### PR TITLE
fix(layout): make off-track phantom target choice hash-seed deterministic

### DIFF
--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -82,19 +82,23 @@ def _insert_phantom_pass_throughs(
         return
     min_layer = min(layers.values())
 
-    entry_port_ids = set(section.entry_ports)
-
-    # Find lines entering from entry ports to deep-layer internal stations.
-    entry_targets: dict[str, set[str]] = {}
-    for pid in entry_port_ids:
+    # Scan entry ports in section order and collect each line's internal
+    # targets in encounter order, so the phantoms inserted below and the order
+    # they are inserted are hash-seed independent.
+    entry_targets: dict[str, list[str]] = {}
+    for pid in section.entry_ports:
         for edge in graph.edges_from(pid):
             if edge.target in sub.stations:
-                entry_targets.setdefault(edge.line_id, set()).add(edge.target)
+                targets = entry_targets.setdefault(edge.line_id, [])
+                if edge.target not in targets:
+                    targets.append(edge.target)
 
     for line_id, targets in entry_targets.items():
         target_layers = [layers.get(t, min_layer) for t in targets]
         if all(ly > min_layer for ly in target_layers):
-            earliest_target = min(targets, key=lambda t: layers.get(t, 0))
+            # Break a tie on earliest layer by station id, so the phantom anchor
+            # is chosen deterministically rather than by hash-seeded iteration.
+            earliest_target = min(targets, key=lambda t: (layers.get(t, 0), t))
             phantom_id = f"_phantom_{section.id}_{line_id}"
 
             sub.add_station(

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -82,9 +82,8 @@ def _insert_phantom_pass_throughs(
         return
     min_layer = min(layers.values())
 
-    # Scan entry ports in section order and collect each line's internal
-    # targets in encounter order, so the phantoms inserted below and the order
-    # they are inserted are hash-seed independent.
+    # Scan entry ports in section order so each line's targets follow port
+    # declaration order.
     entry_targets: dict[str, list[str]] = {}
     for pid in section.entry_ports:
         for edge in graph.edges_from(pid):
@@ -96,8 +95,9 @@ def _insert_phantom_pass_throughs(
     for line_id, targets in entry_targets.items():
         target_layers = [layers.get(t, min_layer) for t in targets]
         if all(ly > min_layer for ly in target_layers):
-            # Break a tie on earliest layer by station id, so the phantom anchor
-            # is chosen deterministically rather than by hash-seeded iteration.
+            # Tie-break earliest layer by station id: for at least one real map
+            # the other candidate deterministically fails the routing
+            # curve-invariant check, so id order is the safe deterministic pick.
             earliest_target = min(targets, key=lambda t: (layers.get(t, 0), t))
             phantom_id = f"_phantom_{section.id}_{line_id}"
 

--- a/tests/data/off_track_phantom_tiebreak.mmd
+++ b/tests/data/off_track_phantom_tiebreak.mmd
@@ -1,154 +1,30 @@
-%%metro title: nf-core/riboseq
-%%metro style: dark
-%%metro diamond_style: symmetric
-%%metro directional: true
-%%metro file: fastq_in | FASTQ
-%%metro file: hybrid_gtf_out | GTF | Hybrid GTF
-%%metro file: orf_catalogue | BED | ORF catalogue
-%%metro file: bigwig_out | BW | Coverage
-%%metro file: report_ribowaltz | HTML | riboWaltz
-%%metro file: te_gene_out | TSV | Gene TE
-%%metro file: te_orf_out | TSV | ORF DTE
-%%metro file: report_final | HTML | MultiQC
-%%metro line: riboseq | Ribo-seq | #e6007e
-%%metro line: rnaseq | Matched RNA-seq | #2db572
-%%metro line: tiseq | TI-seq | #2b6cb0
-%%metro line: annotation | Hybrid annotation | #94a3b8 | dashed
-
-%%metro center_ports: true
-%%metro x_spacing: 70
-
-%%metro grid: preprocessing, alignment, novel_transcripts | 0,0
-%%metro grid: orf_calling, psite, te_gene, te_orf, reporting | 0,1
+%% Minimal off-track phantom pass-through repro: the `alt` line enters the
+%% `fan` section via a port and has two candidate phantom targets (stem and
+%% leaf_a) that tie on earliest layer.
+%%metro title: Off-track phantom tie-break
 graph LR
-    subgraph preprocessing [Read pre-processing]
-        fastq_in[ ]
-        umi_extract[UMI-tools extract]
-        fastp[fastp]
-        trimgalore[Trim Galore!]
-        bbsplit[BBSplit]
-        sortmerna[SortMeRNA]
-        ribodetector[RiboDetector]
-        bowtie2_rrna[Bowtie2]
-        fastqc[FastQC]
-        infer_strand[Infer strandedness]
-        equalise[Equalise\nread lengths]
-
-        fastq_in -->|riboseq,rnaseq,tiseq| umi_extract
-        umi_extract -->|riboseq,rnaseq,tiseq| fastp
-        umi_extract -->|riboseq,rnaseq,tiseq| trimgalore
-        fastp -->|riboseq,rnaseq,tiseq| bbsplit
-        trimgalore -->|riboseq,rnaseq,tiseq| bbsplit
-        bbsplit -->|riboseq,rnaseq,tiseq| sortmerna
-        bbsplit -->|riboseq,rnaseq,tiseq| ribodetector
-        bbsplit -->|riboseq,rnaseq,tiseq| bowtie2_rrna
-        sortmerna -->|riboseq,rnaseq,tiseq| fastqc
-        ribodetector -->|riboseq,rnaseq,tiseq| fastqc
-        bowtie2_rrna -->|riboseq,rnaseq,tiseq| fastqc
-        fastqc -->|riboseq,rnaseq,tiseq| infer_strand
-        infer_strand -->|riboseq,rnaseq,tiseq| equalise
+    subgraph inputs [Inputs]
+        source[Source]
+        gate[Gate]
     end
-
-    subgraph alignment [Alignment & quantification]
-        star[STAR]
-        umi_dedup[UMI-tools dedup]
-        salmon[Salmon]
-        genomecov[Coverage\ntracks]
-
-        star -->|riboseq,rnaseq,tiseq| umi_dedup
-        umi_dedup -->|riboseq,rnaseq,tiseq| salmon
-        umi_dedup -->|riboseq,rnaseq,tiseq| genomecov
-        genomecov -->|riboseq,rnaseq,tiseq| bigwig_out
+    subgraph fan [Fan]
+        hub[Hub]
+        leaf_a[Leaf A]
+        leaf_b[Leaf B]
+        leaf_c[Leaf C]
+        stem[Stem]
+        stem_tail[Stem tail]
+        sink[Sink]
+        hub -->|main| leaf_a
+        hub -->|main| leaf_b
+        hub -->|main| leaf_c
+        hub -->|main| stem
+        stem -->|main| stem_tail
+        leaf_a -->|main| sink
+        leaf_b -->|main| sink
+        leaf_c -->|main| sink
+        stem_tail -->|main| sink
     end
-
-    subgraph novel_transcripts [Transcript discovery]
-        stringtie[StringTie]
-        gffcompare[gffcompare]
-        hybrid_merge[Merge &\nfilter GTF]
-
-        stringtie -->|rnaseq| gffcompare
-        gffcompare -->|rnaseq| hybrid_merge
-        hybrid_merge -->|rnaseq| hybrid_gtf_out
-    end
-
-    subgraph orf_calling [ORF discovery & calling]
-        ribo_bam[Ribo-seq\nalignments]
-        ribotish[Ribo-TISH]
-        ribotricer[Ribotricer]
-        rpbp[Rp-Bp]
-        price[PRICE]
-        star_hybrid[STAR:\nhybrid 2nd pass]
-        ribocode[RiboCode]
-        orf_merge[Merge ORF\ncatalogue]
-
-        ribo_bam -->|riboseq| ribotish
-        ribo_bam -->|riboseq| ribotricer
-        ribo_bam -->|riboseq| rpbp
-        ribo_bam -->|riboseq| price
-        ribo_bam -->|riboseq| star_hybrid
-        star_hybrid -->|riboseq| ribocode
-        ribotish -->|riboseq| orf_merge
-        ribotricer -->|riboseq| orf_merge
-        rpbp -->|riboseq| orf_merge
-        price -->|riboseq| orf_merge
-        ribocode -->|riboseq| orf_merge
-        orf_merge -->|riboseq| orf_catalogue
-    end
-
-    subgraph psite [P-site identification]
-        ribowaltz[riboWaltz]
-        plastid_psite[plastid P-site]
-        plastid_wiggle[plastid wiggle]
-        psite_counts_gene[Gene in-frame\nP-sites]
-        quantify_orf_psite[ORF in-frame\nP-sites]
-
-        ribowaltz -->|riboseq| report_ribowaltz
-        plastid_psite -->|riboseq| plastid_wiggle
-        plastid_wiggle -->|riboseq| psite_counts_gene
-        plastid_wiggle -->|riboseq| quantify_orf_psite
-    end
-
-    subgraph te_gene [Gene-level TE]
-        te_prep_gene[Gene count\nmatrix]
-        anota2seq[anota2seq]
-        deltate[DESeq2 deltaTE]
-
-        te_prep_gene -->|riboseq,rnaseq| anota2seq
-        te_prep_gene -->|riboseq,rnaseq| deltate
-        anota2seq -->|riboseq,rnaseq| te_gene_out
-        deltate -->|riboseq,rnaseq| te_gene_out
-    end
-
-    subgraph te_orf [ORF-level DTE]
-        te_prep_orf[ORF count\nmatrix]
-        anota2seq_orf[anota2seq]
-        deltate_orf[deltaTE]
-        dotseq[DOTSeq]
-
-        te_prep_orf -->|riboseq,rnaseq| anota2seq_orf
-        te_prep_orf -->|riboseq,rnaseq| deltate_orf
-        te_prep_orf -->|riboseq,rnaseq| dotseq
-        anota2seq_orf -->|riboseq,rnaseq| te_orf_out
-        deltate_orf -->|riboseq,rnaseq| te_orf_out
-        dotseq -->|riboseq,rnaseq| te_orf_out
-    end
-
-    subgraph reporting [Reporting]
-        multiqc_final[MultiQC]
-
-        multiqc_final -->|riboseq| report_final
-    end
-
-    equalise -->|riboseq,rnaseq,tiseq| star
-    umi_dedup -->|riboseq| ribo_bam
-    umi_dedup -->|rnaseq| stringtie
-    umi_dedup -->|riboseq| ribowaltz
-    umi_dedup -->|riboseq| plastid_psite
-    hybrid_merge -->|annotation| star_hybrid
-    hybrid_merge -->|annotation| ribotish
-    orf_merge -->|riboseq| quantify_orf_psite
-    psite_counts_gene -->|riboseq| te_prep_gene
-    salmon -->|rnaseq| te_prep_gene
-    quantify_orf_psite -->|riboseq| te_prep_orf
-    salmon -->|rnaseq| te_prep_orf
-    ribowaltz -->|riboseq| multiqc_final
+    source -->|main| hub
+    gate -->|alt| stem
+    gate -->|alt| leaf_a

--- a/tests/data/off_track_phantom_tiebreak.mmd
+++ b/tests/data/off_track_phantom_tiebreak.mmd
@@ -1,0 +1,154 @@
+%%metro title: nf-core/riboseq
+%%metro style: dark
+%%metro diamond_style: symmetric
+%%metro directional: true
+%%metro file: fastq_in | FASTQ
+%%metro file: hybrid_gtf_out | GTF | Hybrid GTF
+%%metro file: orf_catalogue | BED | ORF catalogue
+%%metro file: bigwig_out | BW | Coverage
+%%metro file: report_ribowaltz | HTML | riboWaltz
+%%metro file: te_gene_out | TSV | Gene TE
+%%metro file: te_orf_out | TSV | ORF DTE
+%%metro file: report_final | HTML | MultiQC
+%%metro line: riboseq | Ribo-seq | #e6007e
+%%metro line: rnaseq | Matched RNA-seq | #2db572
+%%metro line: tiseq | TI-seq | #2b6cb0
+%%metro line: annotation | Hybrid annotation | #94a3b8 | dashed
+
+%%metro center_ports: true
+%%metro x_spacing: 70
+
+%%metro grid: preprocessing, alignment, novel_transcripts | 0,0
+%%metro grid: orf_calling, psite, te_gene, te_orf, reporting | 0,1
+graph LR
+    subgraph preprocessing [Read pre-processing]
+        fastq_in[ ]
+        umi_extract[UMI-tools extract]
+        fastp[fastp]
+        trimgalore[Trim Galore!]
+        bbsplit[BBSplit]
+        sortmerna[SortMeRNA]
+        ribodetector[RiboDetector]
+        bowtie2_rrna[Bowtie2]
+        fastqc[FastQC]
+        infer_strand[Infer strandedness]
+        equalise[Equalise\nread lengths]
+
+        fastq_in -->|riboseq,rnaseq,tiseq| umi_extract
+        umi_extract -->|riboseq,rnaseq,tiseq| fastp
+        umi_extract -->|riboseq,rnaseq,tiseq| trimgalore
+        fastp -->|riboseq,rnaseq,tiseq| bbsplit
+        trimgalore -->|riboseq,rnaseq,tiseq| bbsplit
+        bbsplit -->|riboseq,rnaseq,tiseq| sortmerna
+        bbsplit -->|riboseq,rnaseq,tiseq| ribodetector
+        bbsplit -->|riboseq,rnaseq,tiseq| bowtie2_rrna
+        sortmerna -->|riboseq,rnaseq,tiseq| fastqc
+        ribodetector -->|riboseq,rnaseq,tiseq| fastqc
+        bowtie2_rrna -->|riboseq,rnaseq,tiseq| fastqc
+        fastqc -->|riboseq,rnaseq,tiseq| infer_strand
+        infer_strand -->|riboseq,rnaseq,tiseq| equalise
+    end
+
+    subgraph alignment [Alignment & quantification]
+        star[STAR]
+        umi_dedup[UMI-tools dedup]
+        salmon[Salmon]
+        genomecov[Coverage\ntracks]
+
+        star -->|riboseq,rnaseq,tiseq| umi_dedup
+        umi_dedup -->|riboseq,rnaseq,tiseq| salmon
+        umi_dedup -->|riboseq,rnaseq,tiseq| genomecov
+        genomecov -->|riboseq,rnaseq,tiseq| bigwig_out
+    end
+
+    subgraph novel_transcripts [Transcript discovery]
+        stringtie[StringTie]
+        gffcompare[gffcompare]
+        hybrid_merge[Merge &\nfilter GTF]
+
+        stringtie -->|rnaseq| gffcompare
+        gffcompare -->|rnaseq| hybrid_merge
+        hybrid_merge -->|rnaseq| hybrid_gtf_out
+    end
+
+    subgraph orf_calling [ORF discovery & calling]
+        ribo_bam[Ribo-seq\nalignments]
+        ribotish[Ribo-TISH]
+        ribotricer[Ribotricer]
+        rpbp[Rp-Bp]
+        price[PRICE]
+        star_hybrid[STAR:\nhybrid 2nd pass]
+        ribocode[RiboCode]
+        orf_merge[Merge ORF\ncatalogue]
+
+        ribo_bam -->|riboseq| ribotish
+        ribo_bam -->|riboseq| ribotricer
+        ribo_bam -->|riboseq| rpbp
+        ribo_bam -->|riboseq| price
+        ribo_bam -->|riboseq| star_hybrid
+        star_hybrid -->|riboseq| ribocode
+        ribotish -->|riboseq| orf_merge
+        ribotricer -->|riboseq| orf_merge
+        rpbp -->|riboseq| orf_merge
+        price -->|riboseq| orf_merge
+        ribocode -->|riboseq| orf_merge
+        orf_merge -->|riboseq| orf_catalogue
+    end
+
+    subgraph psite [P-site identification]
+        ribowaltz[riboWaltz]
+        plastid_psite[plastid P-site]
+        plastid_wiggle[plastid wiggle]
+        psite_counts_gene[Gene in-frame\nP-sites]
+        quantify_orf_psite[ORF in-frame\nP-sites]
+
+        ribowaltz -->|riboseq| report_ribowaltz
+        plastid_psite -->|riboseq| plastid_wiggle
+        plastid_wiggle -->|riboseq| psite_counts_gene
+        plastid_wiggle -->|riboseq| quantify_orf_psite
+    end
+
+    subgraph te_gene [Gene-level TE]
+        te_prep_gene[Gene count\nmatrix]
+        anota2seq[anota2seq]
+        deltate[DESeq2 deltaTE]
+
+        te_prep_gene -->|riboseq,rnaseq| anota2seq
+        te_prep_gene -->|riboseq,rnaseq| deltate
+        anota2seq -->|riboseq,rnaseq| te_gene_out
+        deltate -->|riboseq,rnaseq| te_gene_out
+    end
+
+    subgraph te_orf [ORF-level DTE]
+        te_prep_orf[ORF count\nmatrix]
+        anota2seq_orf[anota2seq]
+        deltate_orf[deltaTE]
+        dotseq[DOTSeq]
+
+        te_prep_orf -->|riboseq,rnaseq| anota2seq_orf
+        te_prep_orf -->|riboseq,rnaseq| deltate_orf
+        te_prep_orf -->|riboseq,rnaseq| dotseq
+        anota2seq_orf -->|riboseq,rnaseq| te_orf_out
+        deltate_orf -->|riboseq,rnaseq| te_orf_out
+        dotseq -->|riboseq,rnaseq| te_orf_out
+    end
+
+    subgraph reporting [Reporting]
+        multiqc_final[MultiQC]
+
+        multiqc_final -->|riboseq| report_final
+    end
+
+    equalise -->|riboseq,rnaseq,tiseq| star
+    umi_dedup -->|riboseq| ribo_bam
+    umi_dedup -->|rnaseq| stringtie
+    umi_dedup -->|riboseq| ribowaltz
+    umi_dedup -->|riboseq| plastid_psite
+    hybrid_merge -->|annotation| star_hybrid
+    hybrid_merge -->|annotation| ribotish
+    orf_merge -->|riboseq| quantify_orf_psite
+    psite_counts_gene -->|riboseq| te_prep_gene
+    salmon -->|rnaseq| te_prep_gene
+    quantify_orf_psite -->|riboseq| te_prep_orf
+    salmon -->|rnaseq| te_prep_orf
+    ribowaltz -->|riboseq| multiqc_final

--- a/tests/test_hash_seed_determinism.py
+++ b/tests/test_hash_seed_determinism.py
@@ -178,6 +178,20 @@ def test_seed_72_linux_cairosvg_png_is_frozen() -> None:
     )
 
 
+OFF_TRACK_PHANTOM_TIEBREAK = ROOT / "tests" / "data" / "off_track_phantom_tiebreak.mmd"
+
+
+def test_off_track_phantom_tiebreak_is_hash_seed_deterministic() -> None:
+    """Off-track phantom pass-through target choice must not depend on hash seed.
+
+    This riboseq-shaped map has an entry line whose off-track phantom
+    pass-through sees two candidate targets tied on earliest layer.  The chosen
+    target feeds fan ordering and section sizing, so a hash-order-dependent pick
+    makes some seeds render and others abort in routing (issue #1811).
+    """
+    _assert_identical((OFF_TRACK_PHANTOM_TIEBREAK,))
+
+
 def test_same_destination_topologies_render_and_plan_across_hash_seeds() -> None:
     paths = tuple(
         ROOT / "examples" / "topologies" / f"{stem}.mmd"

--- a/tests/test_hash_seed_determinism.py
+++ b/tests/test_hash_seed_determinism.py
@@ -39,6 +39,10 @@ REPRESENTATIVE_CORPUS = (
     "examples/topologies/packed_cell_cellmate_bypass.mmd",
     "examples/topologies/u_turn_fold.mmd",
     "examples/topologies/wide_fan_out.mmd",
+    # Two of the `alt` line's phantom pass-through targets tie on earliest
+    # layer; the layout must pick the same one under every hash seed, so this
+    # map settles and renders identically here.
+    "tests/data/off_track_phantom_tiebreak.mmd",
 )
 
 
@@ -176,20 +180,6 @@ def test_seed_72_linux_cairosvg_png_is_frozen() -> None:
     assert hashlib.sha256(png).hexdigest() == (
         "c951485a7fe6338db39691c68116eb104312c1d9e545bd049c986dbc0b9083b9"
     )
-
-
-OFF_TRACK_PHANTOM_TIEBREAK = ROOT / "tests" / "data" / "off_track_phantom_tiebreak.mmd"
-
-
-def test_off_track_phantom_tiebreak_is_hash_seed_deterministic() -> None:
-    """Off-track phantom pass-through target choice must not depend on hash seed.
-
-    This riboseq-shaped map has an entry line whose off-track phantom
-    pass-through sees two candidate targets tied on earliest layer.  The chosen
-    target feeds fan ordering and section sizing, so a hash-order-dependent pick
-    makes some seeds render and others abort in routing (issue #1811).
-    """
-    _assert_identical((OFF_TRACK_PHANTOM_TIEBREAK,))
 
 
 def test_same_destination_topologies_render_and_plan_across_hash_seeds() -> None:


### PR DESCRIPTION
## Summary
- `_insert_phantom_pass_throughs` in `src/nf_metro/layout/phases/off_track.py` picked a phantom pass-through's successor via `min()` over a `set[str]` of tied-layer candidate targets. Python randomizes `str`/`bytes` hashing per process (`PYTHONHASHSEED`), so on a map with an entry line feeding two or more stations at the same earliest layer, the chosen target — and everything downstream of it (predecessor averages, fan track assignment, section width/height, and in one real shape a hard `CurveInvariantError` render abort) — could differ between otherwise-identical renders depending only on which process ran them.
- Fixed by removing both hash-order-dependent constructs: the entry-port scan now iterates the section's already-ordered `entry_ports` list directly (no `set()` wrap), and candidate targets are collected into an order-preserving structure instead of a `set`. The remaining layer tie is broken with a `(layer, station_id)` key rather than encounter order, because encounter order happens to pick a target that deterministically aborts the render on the motivating real map — this is a considered, documented trade-off, not an oversight.
- Added a regression test (`tests/test_hash_seed_determinism.py`) that renders a minimal synthetic fixture (`tests/data/off_track_phantom_tiebreak.mmd`, deliberately outside the gallery/topology auto-discovery roots — see note below) under several `PYTHONHASHSEED` values via the existing cross-process oracle and asserts byte-identical output. It fails on `main` (some seeds render, others abort) and passes with this fix.
- No runtime validator added: this is a structural, input-independent tie-break bug (no layout property to guard beyond what the new test already pins).
- Swept the full committed corpus (`examples/*.mmd`, `examples/topologies/*.mmd`, `tests/fixtures/**/*.mmd`, 381 files) across multiple hash seeds: none currently flip, so this defect was latent on shipped content and this PR carries no gallery-visible delta.

**On fixture placement:** the new `.mmd` is a minimal synthetic repro for a determinism property, not a gallery-worthy pipeline diagram, so it's kept out of `tests/fixtures/`, `examples/`, `examples/topologies/`, and `examples/guide/` to avoid the guard-trace-golden/gallery/corpus-digest obligations those roots carry for what would otherwise be an unrelated new topology fixture. It is exercised only by its own targeted test.

Fixes #1811

## Test plan
- [x] New regression test (`tests/test_hash_seed_determinism.py`) fails on `main`, passes with this fix — verified independently
- [x] `ruff check` + `ruff format --check` clean on the whole repo
- [x] Routing gate-coverage ratchet and guard-trace golden confirmed **not** tripped (fix is outside `layout/routing/`; fixture is outside all auto-discovered roots)
- [ ] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1875/)
- [ ] Render-preview verdict: expected "no visual changes detected" (0/381 corpus fixtures affected per pre-fix sweep)