### PR TITLE
chore: fix the packaging, README and release-CI surfaces a stranger meets first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,56 @@ jobs:
           --splitting-algorithm least_duration --durations=25
           --ignore=tests/test_routing_gate_coverage.py
 
+  wheel-smoke:
+    name: Wheel smoke test (Python 3.12)
+    needs: [lint, format]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - run: pip install build twine
+      - run: python -m build
+      - run: twine check --strict dist/*
+
+      # Package data lives under src/nf_metro but is not Python, so nothing
+      # imports it and a build-config slip drops it silently.
+      - name: Check the wheel ships its package data and no internal docs
+        run: |
+          contents=$(python -m zipfile -l dist/*.whl)
+          for path in \
+            nf_metro/py.typed \
+            nf_metro/fonts/Inter-Regular.woff2 \
+            nf_metro/fonts/Inter-Bold.woff2 \
+            nf_metro/fonts/LICENSE.txt \
+            nf_metro/live/state_schema.json \
+            nf_metro/manifest/schema.json \
+            nf_metro/render/driver.js \
+            nf_metro/render/inline.html \
+            nf_metro/render/standalone.html
+          do
+            grep -qF "$path" <<<"$contents" || { echo "wheel is missing $path"; exit 1; }
+          done
+          ! grep -qF "CONTRACT.md" <<<"$contents" || { echo "wheel ships CONTRACT.md"; exit 1; }
+
+      # A venv and a working directory both outside the checkout: an import that
+      # only resolves because src/ is on the path, or a resource addressed by a
+      # repo-relative path, fails here and nowhere else in CI.
+      - name: Render an example from a clean venv outside the repo
+        run: |
+          python -m venv "$RUNNER_TEMP/smoke"
+          "$RUNNER_TEMP/smoke/bin/pip" install dist/*.whl
+          cd "$RUNNER_TEMP"
+          "$RUNNER_TEMP/smoke/bin/nf-metro" --version
+          "$RUNNER_TEMP/smoke/bin/nf-metro" --help
+          "$RUNNER_TEMP/smoke/bin/nf-metro" render \
+            "$GITHUB_WORKSPACE/examples/simple_pipeline.mmd" -o smoke.svg
+          test -s smoke.svg
+
   routing-gates:
     name: Routing gate coverage (Python 3.11)
     needs: [lint, format]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,20 +16,37 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-      - run: pip install build
+      - run: pip install build packaging
       - run: python -m build
 
       # PyPI takes the version from the artefact, not the tag, so a tag cut
       # against an unbumped tree would publish under the previous version.
+      # A wheel filename carries the PEP 427 normalised version, so the two
+      # sides are compared as parsed versions rather than as strings.
       - name: Check the release tag matches the built version
         env:
           TAG: ${{ github.event.release.tag_name }}
         run: |
-          built=$(basename dist/*.whl | cut -d- -f2)
-          if [ "$built" != "${TAG#v}" ]; then
-            echo "release tag $TAG does not match built version $built"
-            exit 1
-          fi
+          python - <<'PY'
+          import glob
+          import os
+          import sys
+          from packaging.version import InvalidVersion, Version
+
+          wheels = sorted(glob.glob("dist/*.whl"))
+          if len(wheels) != 1:
+              sys.exit(f"expected exactly one wheel in dist/, found {wheels}")
+
+          built = os.path.basename(wheels[0]).split("-")[1]
+          tag = os.environ["TAG"]
+          try:
+              match = Version(built) == Version(tag.removeprefix("v"))
+          except InvalidVersion as error:
+              sys.exit(f"cannot compare release tag {tag!r} with built version {built!r}: {error}")
+          if not match:
+              sys.exit(f"release tag {tag} does not match built version {built}")
+          print(f"release tag {tag} matches built version {built}")
+          PY
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,18 @@ jobs:
           python-version: "3.12"
       - run: pip install build
       - run: python -m build
+
+      # PyPI takes the version from the artefact, not the tag, so a tag cut
+      # against an unbumped tree would publish under the previous version.
+      - name: Check the release tag matches the built version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          built=$(basename dist/*.whl | cut -d- -f2)
+          if [ "$built" != "${TAG#v}" ]; then
+            echo "release tag $TAG does not match built version $built"
+            exit 1
+          fi
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist

--- a/README.md
+++ b/README.md
@@ -67,26 +67,10 @@ Requires Python 3.11+.
 
 ## Quick start
 
-Render a metro map from a `.mmd` file:
+Write a two-line pipeline to `pipeline.mmd`:
 
 ```bash
-nf-metro render examples/simple_pipeline.mmd -o pipeline.svg
-```
-
-Check your input without rendering, or see what nf-metro made of it:
-
-```bash
-nf-metro validate examples/simple_pipeline.mmd
-nf-metro info examples/simple_pipeline.mmd
-```
-
-Every command takes `--help`, and the [CLI reference](https://seqeralabs.github.io/nf-metro/latest/cli/) documents each one and every option it accepts. The [Guide](https://seqeralabs.github.io/nf-metro/latest/guide/) is a step-by-step walkthrough of writing `.mmd` files, ending in the full [directive reference](https://seqeralabs.github.io/nf-metro/latest/guide/#directive-reference).
-
-## Input format
-
-Input files are a subset of Mermaid `graph LR` syntax extended with `%%metro` directives. Global directives configure the map, section directives inside `subgraph` blocks control section layout, and edges carry the line IDs that pass along them:
-
-```
+cat > pipeline.mmd <<'EOF'
 %%metro title: Simple Pipeline
 %%metro line: main | Main | #4CAF50
 %%metro line: qc | Quality Control | #2196F3 | dashed
@@ -101,9 +85,29 @@ graph LR
     trim -->|main| align
     input -->|qc| fastqc
     trim -->|qc| fastqc
+EOF
 ```
 
-That is the whole of [`examples/simple_pipeline.mmd`](https://github.com/seqeralabs/nf-metro/blob/main/examples/simple_pipeline.mmd) bar a couple of stations. From there the [Guide](https://seqeralabs.github.io/nf-metro/latest/guide/) covers sections, entry and exit ports, grid placement, file and folder icons, off-track stations, inactive lines and the rest, directive by directive.
+Render it:
+
+```bash
+nf-metro render pipeline.mmd -o pipeline.svg
+```
+
+Check the input without rendering, or see what nf-metro made of it:
+
+```bash
+nf-metro validate pipeline.mmd
+nf-metro info pipeline.mmd
+```
+
+Every command takes `--help`, and the [CLI reference](https://seqeralabs.github.io/nf-metro/latest/cli/) documents each one and every option it accepts. The [Guide](https://seqeralabs.github.io/nf-metro/latest/guide/) is a step-by-step walkthrough of writing `.mmd` files, ending in the full [directive reference](https://seqeralabs.github.io/nf-metro/latest/guide/#directive-reference).
+
+## Input format
+
+Input files are a subset of Mermaid `graph LR` syntax extended with `%%metro` directives. The map above uses only global directives, which configure the whole map, plus edges carrying the line IDs that pass along them. Section directives inside Mermaid `subgraph` blocks control how each section is laid out.
+
+From there the [Guide](https://seqeralabs.github.io/nf-metro/latest/guide/) covers sections, entry and exit ports, grid placement, file and folder icons, off-track stations, inactive lines and the rest, directive by directive.
 
 ## Interactive HTML output
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ A pre-built container is available via [Seqera Containers](https://seqera.io/con
 docker pull community.wave.seqera.io/library/pip_nf-metro:611b1ba39c6007f1
 ```
 
+### Extras
+
+Two features need a dependency the base install leaves out:
+
+```bash
+pip install "nf-metro[validate]"   # nf-metro validate-svg (jsonschema)
+pip install "nf-metro[font]"       # render --text-to-paths (fonttools)
+```
+
 ### Development
 
 ```bash
@@ -64,362 +73,89 @@ Render a metro map from a `.mmd` file:
 nf-metro render examples/simple_pipeline.mmd -o pipeline.svg
 ```
 
-Validate your input without rendering:
+Check your input without rendering, or see what nf-metro made of it:
 
 ```bash
 nf-metro validate examples/simple_pipeline.mmd
-```
-
-Inspect structure (sections, lines, stations):
-
-```bash
 nf-metro info examples/simple_pipeline.mmd
 ```
 
-See the [Guide](https://seqeralabs.github.io/nf-metro/latest/guide/) for a step-by-step walkthrough of writing `.mmd` files.
+Every command takes `--help`, and the [CLI reference](https://seqeralabs.github.io/nf-metro/latest/cli/) documents each one and every option it accepts. The [Guide](https://seqeralabs.github.io/nf-metro/latest/guide/) is a step-by-step walkthrough of writing `.mmd` files, ending in the full [directive reference](https://seqeralabs.github.io/nf-metro/latest/guide/#directive-reference).
 
-## CLI reference
+## Input format
 
-### `nf-metro render`
+Input files are a subset of Mermaid `graph LR` syntax extended with `%%metro` directives. Global directives configure the map, section directives inside `subgraph` blocks control section layout, and edges carry the line IDs that pass along them:
 
-Render a Mermaid metro map definition to SVG or interactive HTML.
+```
+%%metro title: Simple Pipeline
+%%metro line: main | Main | #4CAF50
+%%metro line: qc | Quality Control | #2196F3 | dashed
 
-```bash
-nf-metro render [OPTIONS] INPUT_FILE
+graph LR
+    input[Input]
+    fastqc[FastQC]
+    trim[Trimming]
+    align[Alignment]
+
+    input -->|main| trim
+    trim -->|main| align
+    input -->|qc| fastqc
+    trim -->|qc| fastqc
 ```
 
-Every layout/render option below also has a `%%metro` directive equivalent in the `.mmd` file; an explicitly-passed flag overrides the directive.
+That is the whole of [`examples/simple_pipeline.mmd`](https://github.com/seqeralabs/nf-metro/blob/main/examples/simple_pipeline.mmd) bar a couple of stations. From there the [Guide](https://seqeralabs.github.io/nf-metro/latest/guide/) covers sections, entry and exit ports, grid placement, file and folder icons, off-track stations, inactive lines and the rest, directive by directive.
 
-| Option                                     | Default                      | Description                                                                                  |
-| ------------------------------------------ | ---------------------------- | -------------------------------------------------------------------------------------------- |
-| `-o`, `--output PATH`                      | `<input>.<format>`           | Output file path                                                                             |
-| `--format [svg\|html]`                     | `svg`                        | Output format: `svg` or interactive `html`                                                   |
-| `--theme [nfcore\|light\|seqera]`          | from `style:`, else `nfcore` | Visual theme                                                                                 |
-| `--legend TEXT`                            | auto                         | Legend+logo position (keyword, `keyword \| canvas`, `keyword \| dx,dy`, or `x,y`)            |
-| `--line-spread [bundle\|centered\|rails]`  | `bundle`                     | How lines sharing a station relate vertically                                                |
-| `--width INTEGER`                          | auto                         | SVG width in pixels                                                                          |
-| `--height INTEGER`                         | auto                         | SVG height in pixels                                                                         |
-| `--x-spacing FLOAT`                        | auto                         | Horizontal spacing between layers                                                            |
-| `--y-spacing FLOAT`                        | auto                         | Vertical spacing between tracks                                                              |
-| `--fold-threshold INTEGER`                 | `15`                         | Max station-columns a section row may reach before wrapping to the next row                  |
-| `--animate / --no-animate`                 | off                          | Add animated balls traveling along lines                                                     |
-| `--directional / --no-directional`         | off                          | Draw static chevrons along each route pointing in the flow direction                         |
-| `--strict / --no-strict`                   | off                          | Treat a layout-invariant violation as an error instead of a warning                          |
-| `--debug / --no-debug`                     | off                          | Show debug overlay (ports, hidden stations, edge waypoints)                                  |
-| `--logo PATH`                              | none                         | Logo image path (overrides `%%metro logo:` directive)                                        |
-| `--line-order [definition\|span]`          | `definition`                 | Line ordering strategy: `definition` preserves `.mmd` order, `span` sorts by section span    |
-| `--diamond-style [straight\|symmetric]`    | `straight`                   | Fork-join layout: `straight` keeps the top branch on the main track; `symmetric` fans evenly |
-| `--center-ports / --no-center-ports`       | off                          | Centre inter-section ports on the shorter of the two connected sections                      |
-| `--compact-offsets / --no-compact-offsets` | off                          | Size each station only for the lines actually passing through it                             |
-| `--section-x-gap FLOAT`                    | `50`                         | Horizontal gap between sections                                                              |
-| `--section-y-gap FLOAT`                    | `50`                         | Vertical gap between sections                                                                |
-| `--label-angle FLOAT`                      | theme default                | Station-label angle in degrees                                                               |
-| `--font-scale FLOAT`                       | `1.0`                        | Scale text and the label metrics that drive layout spacing                                   |
-| `--logo-scale FLOAT`                       | `1.0`                        | Scale the logo within the legend                                                             |
-| `--legend-min-height FLOAT`                | `0`                          | Minimum legend content height in pixels                                                      |
-| `--legend-logo-gap FLOAT`                  | auto                         | Gap between the logo and the legend entries                                                  |
-| `--validate`                               | off                          | Run the render-geometry oracle over the drawn SVG and report violations                      |
-| `--from-nextflow`                          | off                          | Convert Nextflow `-with-dag` mermaid input before rendering                                  |
-| `--title TEXT`                             | none                         | Pipeline title (overrides the `%%metro title:` directive)                                    |
+## Interactive HTML output
 
-#### Embedding options
-
-Flags for producing an SVG to embed in another page or application. See the
-[embedding guide](https://seqeralabs.github.io/nf-metro/latest/embedding/) for when to use each.
-
-| Option                                 | Default | Description                                                                                        |
-| -------------------------------------- | ------- | -------------------------------------------------------------------------------------------------- |
-| `--responsive / --no-responsive`       | off     | Emit `viewBox` only (no fixed `width`/`height`) so the host can scale with CSS                     |
-| `--embed-font / --no-embed-font`       | off     | Inline Inter as a base64 `@font-face` so the SVG renders identically on any host                   |
-| `--text-to-paths / --no-text-to-paths` | off     | Convert text to vector paths (no font dependency; loses selectable text; needs `fonttools[woff]`)  |
-| `--bare / --no-bare`                   | off     | Omit the title and outer padding so the canvas hugs the content (keeps the watermark)              |
-| `--svg-class-prefix TEXT`              | none    | Prefix every SVG presentation class so multiple maps on one page don't collide                     |
-| `--no-dark-mode-css`                   | off     | Suppress the `prefers-color-scheme: dark` block when the host manages its own theme                |
-| `--no-chrome-css`                      | off     | Bake concrete chrome colors instead of `--nfm-*` `var()` (needed for raster export, e.g. cairosvg) |
-
-The `--logo` flag lets you use the same `.mmd` file with different logos per theme:
-
-```bash
-nf-metro render pipeline.mmd -o pipeline_dark.svg --theme nfcore --logo logo_dark.png
-nf-metro render pipeline.mmd -o pipeline_light.svg --theme light --logo logo_light.png
-```
-
-#### Interactive HTML output
-
-`--format html` produces a self-contained `.html` file with the SVG inlined plus a small JS/CSS layer (no external dependencies, no network):
+`--format html` produces a self-contained page with the SVG inlined plus a small JS/CSS layer (no external dependencies, no network):
 
 ```bash
 nf-metro render pipeline.mmd --format html -o pipeline.html
 ```
 
-The page provides:
+Drag to pan, scroll to zoom, hover a station for its label, section and lines, and click a line in the legend to isolate it and zoom to its extent. An **Embed...** panel copies out a snippet for a host page: inline HTML that keeps full interactivity, an iframe one-liner, or the raw `<svg>` for contexts that strip scripts.
 
-- **Drag to pan**, **scroll to zoom** (Cmd/Ctrl+scroll in embedded mode).
-- **Hover a station** to see its label, section, and the lines passing through it.
-- **Click a line in the legend** to isolate it. Stations and sections not carrying that line disappear and the view zooms to the bounding box of what remains. Click again, hit `Esc`, or use the **Reset** button to restore.
-- **Embed...** opens a copy-snippet panel with three options:
-  - **Inline HTML** - a self-contained `<div>` you paste into any HTML host (MkDocs, Confluence, Notion, blog templates). Keeps full interactivity, no iframe.
-  - **iframe** - a one-liner pointing at the hosted `.html` file.
-  - **Static SVG** - the raw `<svg>` markup for contexts that strip scripts.
-
-GitHub READMEs strip `<script>` tags, so embed there as a static SVG (or link out to a hosted version). Most static-site generators and internal wikis run the inline-HTML snippet as-is.
-
-#### Embedded data manifest
-
-Every rendered SVG carries a machine-readable manifest so the committed file is a self-contained artifact - a downstream tool can position overlays, restyle nodes, or look up which processes a node represents without re-running the layout engine. The data is carried as a JSON block in a `<metadata id="diagram-manifest">` element and as `data-node-*` attributes on each station's `<g>` element.
-
-Set `%%metro manifest: false` (or `--no-manifest`) to emit the drawn map without a manifest. See the [Data manifest](https://seqeralabs.github.io/nf-metro/latest/manifest/) docs for the full schema and how to consume it.
-
-### `nf-metro validate`
-
-Check a `.mmd` file for errors without producing output.
-
-```bash
-nf-metro validate [OPTIONS] INPUT_FILE
-```
-
-| Option          | Default | Description                                              |
-| --------------- | ------- | -------------------------------------------------------- |
-| `--with-layout` | off     | Also run the layout engine with its full invariant suite |
-| `--strict`      | off     | Treat warnings as errors                                 |
-
-### `nf-metro validate-svg`
-
-Run geometry checks on an already-rendered SVG (without re-running the layout engine).
-
-```bash
-nf-metro validate-svg [OPTIONS] SVG_FILE
-```
-
-| Option       | Default | Description                                                                                                            |
-| ------------ | ------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `--geometry` | off     | Check that routes don't pass through station labels or markers, and that distinct lines don't collapse onto one stroke |
-
-### `nf-metro info`
-
-Print a summary of the parsed map: sections, lines, stations, and edges.
-
-```bash
-nf-metro info INPUT_FILE
-```
-
-### `nf-metro convert`
-
-Convert a Nextflow `-with-dag` mermaid file to nf-metro `.mmd` format. The output can be rendered directly or hand-tuned first.
-
-```bash
-nf-metro convert [OPTIONS] INPUT_FILE
-```
-
-| Option                | Default | Description                             |
-| --------------------- | ------- | --------------------------------------- |
-| `-o`, `--output PATH` | stdout  | Output `.mmd` file path                 |
-| `--title TEXT`        | auto    | Pipeline title for the converted output |
-
-To convert and render in one step, use the `--from-nextflow` flag on `render` instead. See [Importing from Nextflow](https://seqeralabs.github.io/nf-metro/latest/nextflow/) for details.
-
-### `nf-metro serve`
-
-Host a metro map and light up stations in real time as a Nextflow pipeline runs. Point Nextflow's `-with-weblog` at the server; stations transition from pending to running to done as tasks complete. No Seqera Platform, no plugin required.
-
-```bash
-nf-metro serve path/to/map.mmd --port 8080
-# then in another shell:
-nextflow run my/pipeline -with-weblog http://localhost:8080/events
-```
-
-| Option      | Default     | Description                                                |
-| ----------- | ----------- | ---------------------------------------------------------- |
-| `--port`    | `8080`      | Port to listen on                                          |
-| `--host`    | `127.0.0.1` | Interface to bind (`0.0.0.0` to accept remote connections) |
-| `--theme`   | `nfcore`    | Visual theme (`nfcore`, `light`, `seqera`)                 |
-| `--overlay` | `ring`      | Status overlay style: `ring`, `pulse`, `dot`, `led`        |
-| `--token`   | none        | Require `?token=` or `X-Metro-Token` header on `/events`   |
-
-Stations must be mapped to Nextflow process names with `%%metro process:` directives (see the [directive reference](#directive-reference) and the [live progress guide](https://seqeralabs.github.io/nf-metro/latest/live/)).
-
-### `nf-metro serve-multi`
-
-Long-lived dashboard mode: each pipeline or run registers its own map and gets a stable `/r/<id>/` URL. Useful for running many pipelines side by side or keeping a history of runs.
-
-```bash
-nf-metro serve-multi --port 8080
-
-# register a map (returns JSON with "id" and "events")
-curl -s --data-binary @map.mmd "http://localhost:8080/maps?name=myrun"
-# point Nextflow at the per-run events endpoint
-nextflow run my/pipeline -with-weblog "http://localhost:8080/r/<id>/events"
-```
-
-See the [live progress guide](https://seqeralabs.github.io/nf-metro/latest/live/) for the full dashboard workflow and the optional Nextflow plugin that handles registration automatically.
-
-### `nf-metro check-mapping`
-
-Audit a `.mmd` file's `%%metro process:` directives against a real Nextflow process graph and report drift: processes with no station (invisible), stale patterns that match nothing, and processes matching more than one station (duplicated progress). Exits non-zero when it finds problems, so it can gate CI.
-
-```bash
-nextflow run my/pipeline -with-dag dag.mmd -preview
-nf-metro check-mapping path/to/map.mmd --dag dag.mmd
-```
-
-| Option               | Default | Description                                                                        |
-| -------------------- | ------- | ---------------------------------------------------------------------------------- |
-| `--dag <file>`       | -       | Nextflow `-with-dag` Mermaid export                                                |
-| `--processes <file>` | -       | Newline-delimited list of process names (alternative to `--dag`)                   |
-| `--ignore <regex>`   | -       | Processes deliberately left unmapped (e.g. `.*:DUMPSOFTWAREVERSIONS`). Repeatable. |
-
-## Examples
-
-The [`examples/`](examples/) directory contains ready-to-render `.mmd` files:
-
-| Example                                               | Description                                    |
-| ----------------------------------------------------- | ---------------------------------------------- |
-| [`simple_pipeline.mmd`](examples/simple_pipeline.mmd) | Minimal two-line pipeline with no sections     |
-| [`rnaseq_auto.mmd`](examples/rnaseq_auto.mmd)         | nf-core/rnaseq with fully auto-inferred layout |
-| [`rnaseq_sections.mmd`](examples/rnaseq_sections.mmd) | nf-core/rnaseq with manual grid overrides      |
-
-### Topology gallery
-
-The [`examples/topologies/`](examples/topologies/) directory has 38 examples covering a range of layout patterns. See the [topology README](examples/topologies/README.md) for descriptions and rendered previews, or browse the [online gallery](https://seqeralabs.github.io/nf-metro/latest/gallery/).
-
-A few highlights:
-
-|                                                       |                                                                 |                                                             |
-| :---------------------------------------------------: | :-------------------------------------------------------------: | :---------------------------------------------------------: |
-|                   **Wide Fan-Out**                    |                       **Section Diamond**                       |                     **Variant Calling**                     |
-| ![Wide Fan-Out](examples/topologies/wide_fan_out.png) |   ![Section Diamond](examples/topologies/section_diamond.png)   | ![Variant Calling](examples/topologies/variant_calling.png) |
-|                  **Fold Serpentine**                  |                      **Multi-Line Bundle**                      |                      **RNA-seq Lite**                       |
-|  ![Fold Double](examples/topologies/fold_double.png)  | ![Multi-Line Bundle](examples/topologies/multi_line_bundle.png) |    ![RNA-seq Lite](examples/topologies/rnaseq_lite.png)     |
-
-## Input format
-
-Input files use a subset of Mermaid `graph LR` syntax extended with `%%metro` directives. The format has three layers: **global directives** that configure the overall map, **section directives** inside `subgraph` blocks that control section layout, and **edges** that define connections between stations.
-
-The [Guide](https://seqeralabs.github.io/nf-metro/latest/guide/) walks through the format step by step, from a minimal flat pipeline to a multi-section map with custom grid layout. The walkthrough below covers the key ideas.
-
-### Walkthrough: nf-core/rnaseq
-
-The full example is at [`examples/rnaseq_sections.mmd`](examples/rnaseq_sections.mmd).
-
-#### Global directives
-
-```
-%%metro title: nf-core/rnaseq
-%%metro logo: examples/nf-core-rnaseq_logo_dark.png
-%%metro style: dark
-```
-
-- `title:` sets the map title (shown top-left unless a logo is provided)
-- `logo:` embeds a PNG image in place of the text title
-- `style:` selects a theme (`dark` or `light`)
-
-#### Lines (routes)
-
-Each metro line represents a distinct path through the pipeline:
-
-```
-%%metro line: star_rsem | Aligner: STAR, Quantification: RSEM | #0570b0
-%%metro line: star_salmon | Aligner: STAR, Quantification: Salmon (default) | #2db572
-%%metro line: hisat2 | Aligner: HISAT2, Quantification: None | #f5c542
-%%metro line: pseudo_salmon | Pseudo-aligner: Salmon, Quantification: Salmon | #e63946
-%%metro line: pseudo_kallisto | Pseudo-aligner: Kallisto, Quantification: Kallisto | #7b2d3b
-```
-
-An optional fourth field sets the stroke style: `solid` (default), `dashed`, or `dotted`.
-
-#### Grid placement
-
-Sections are placed automatically via topological sort, but explicit positions can be set:
-
-```
-%%metro grid: postprocessing | 2,0,2
-%%metro grid: qc_report | 1,2,1,2
-```
-
-The format is `section_id | col,row[,rowspan[,colspan]]`.
-
-#### Sections
-
-Sections are Mermaid `subgraph` blocks. Entry and exit hints control which side the port appears on:
-
-```
-graph LR
-    subgraph preprocessing [Pre-processing]
-        %%metro exit: right | star_salmon, star_rsem, hisat2
-        %%metro exit: bottom | pseudo_salmon, pseudo_kallisto
-        cat_fastq[cat fastq]
-        fastqc_raw[FastQC]
-        ...
-    end
-```
-
-- `%%metro entry: <side> | <line_ids>` - which lines enter and from which side (`left`, `right`, `top`, `bottom`)
-- `%%metro exit: <side> | <line_ids>` - which lines exit and to which side
-- `%%metro direction: <dir>` - section flow direction: `LR` (default), `RL` (right-to-left), or `TB` (top-to-bottom)
-- `%%metro number: <positive_integer>` - override the section's number badge
-
-#### Stations and edges
-
-Stations use Mermaid node syntax. Edges carry comma-separated line IDs:
-
-```
-        cat_fastq -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| fastqc_raw
-        star -->|star_rsem| rsem
-        star -->|star_salmon| umi_tools_dedup
-```
-
-#### Inter-section edges
-
-Edges between stations in different sections go outside all `subgraph`/`end` blocks. They are automatically rewritten into port-to-port connections with junction stations at fan-out points:
-
-```
-    sortmerna -->|star_salmon,star_rsem| star
-    sortmerna -->|hisat2| hisat2_align
-    sortmerna -->|pseudo_salmon| salmon_pseudo
-    sortmerna -->|pseudo_kallisto| kallisto
-```
-
-### Directive reference
-
-| Directive                                                        | Scope            | Description                                                                                                                                                                                      |
-| ---------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `%%metro title: <text>`                                          | Global           | Map title                                                                                                                                                                                        |
-| `%%metro logo: <path>`                                           | Global           | Logo image (replaces title text)                                                                                                                                                                 |
-| `%%metro logo_scale: <factor>`                                   | Global           | Scale the logo within the legend block                                                                                                                                                           |
-| `%%metro style: <name>`                                          | Global           | Theme: `dark`, `light`                                                                                                                                                                           |
-| `%%metro line: <id> \| <name> \| <color> [\| <style>]`           | Global           | Define a metro line. Optional style: `solid` (default), `dashed`, `dotted`                                                                                                                       |
-| `%%metro grid: <section> \| <col>,<row>[,<rowspan>[,<colspan>]]` | Global           | Pin section to grid position                                                                                                                                                                     |
-| `%%metro legend: <position>`                                     | Global           | Legend position: `tl`, `tr`, `bl`, `br`, `bottom`, `right`, `none` (append `\| canvas`, `\| <dx>,<dy>`, or use `<x>,<y>` - see the [guide](https://seqeralabs.github.io/nf-metro/latest/guide/)) |
-| `%%metro line_order: <strategy>`                                 | Global           | Line ordering: `definition` (default) or `span`                                                                                                                                                  |
-| `%%metro file: <station> \| <label> [\| <name>] [\| banner]`     | Global           | Mark a station as a file terminus with a document icon                                                                                                                                           |
-| `%%metro files: <station> \| <label> [\| <name>] [\| banner]`    | Global           | Mark a station with a stacked-documents icon (e.g. paired files)                                                                                                                                 |
-| `%%metro dir: <station> \| <label> [\| <name>]`                  | Global           | Mark a station with a folder icon                                                                                                                                                                |
-| `%%metro off_track: <station>[, <station>...]`                   | Global           | Lift listed stations above the main track, anchored to their producer/consumer                                                                                                                   |
-| `%%metro process: <station> \| <regex>`                          | Global           | Map a station to a Nextflow process name regex for live progress; repeatable                                                                                                                     |
-| `%%metro compact_offsets: true`                                  | Global           | Use compact per-station offsets instead of global line-priority slots                                                                                                                            |
-| `%%metro center_ports: true`                                     | Global           | Centre inter-section ports on the shorter of the two connected sections                                                                                                                          |
-| `%%metro line_spread: <mode>[ \| <section>...]`                  | Global / Section | How lines sharing a station relate vertically: `bundle` (default), `centered`, `rails`                                                                                                           |
-| `%%metro animate: true`                                          | Global           | Add animated balls traveling along lines (same as `--animate`)                                                                                                                                   |
-| `%%metro directional: true`                                      | Global           | Draw static flow-direction chevrons (same as `--directional`)                                                                                                                                    |
-| `%%metro manifest: false`                                        | Global           | Omit the embedded data manifest from the rendered SVG                                                                                                                                            |
-| `%%metro legend_min_height: <pixels>`                            | Global           | Minimum legend content height in pixels                                                                                                                                                          |
-| `%%metro entry: <side> \| <lines>`                               | Section          | Entry port hint                                                                                                                                                                                  |
-| `%%metro exit: <side> \| <lines>`                                | Section          | Exit port hint                                                                                                                                                                                   |
-| `%%metro direction: <dir>`                                       | Section          | Flow direction: `LR`, `RL`, `TB`                                                                                                                                                                 |
-| `%%metro number: <positive_integer>`                             | Section          | Override the section's number badge                                                                                                                                                              |
+GitHub READMEs are one of those contexts, so embed there as a static SVG (or link out to a hosted version). Most static-site generators and internal wikis run the inline-HTML snippet as-is. See the [embedding guide](https://seqeralabs.github.io/nf-metro/latest/embedding/) for the options.
 
 ## Live progress
 
-nf-metro can light up a metro map in real time as a Nextflow pipeline runs. Map stations to Nextflow processes with `%%metro process:` directives, then start the server:
+nf-metro can light up a metro map in real time as a Nextflow pipeline runs. Map stations to Nextflow processes with `%%metro process:` directives, then start the server and point Nextflow's `-with-weblog` at it:
 
 ```bash
 nf-metro serve path/to/map.mmd
 nextflow run my/pipeline -with-weblog http://localhost:8080/events
 ```
 
-Stations transition from pending to running to done as tasks are submitted and complete. The layout is computed once; the overlay is drawn on top, so the map never re-flows during a run.
+Stations transition from pending to running to done as tasks are submitted and complete. The layout is computed once and the overlay is drawn on top, so the map never re-flows during a run. `nf-metro serve-multi` is the dashboard version: each pipeline or run registers its own map and gets a stable `/r/<id>/` URL.
 
 For multi-pipeline dashboards, persistent history, and the optional Nextflow plugin that handles wiring automatically, see the [live progress guide](https://seqeralabs.github.io/nf-metro/latest/live/).
+
+## Embedded data manifest
+
+Every rendered SVG carries a machine-readable manifest, so the committed file is a self-contained artifact: a downstream tool can position overlays, restyle nodes, or look up which processes a node represents without re-running the layout engine. The data travels as a JSON block in a `<metadata id="diagram-manifest">` element and as `data-node-*` attributes on each station's `<g>` element. See the [data manifest](https://seqeralabs.github.io/nf-metro/latest/manifest/) docs for the schema and how to consume it.
+
+## Examples
+
+The [`examples/`](https://github.com/seqeralabs/nf-metro/tree/main/examples) directory contains ready-to-render `.mmd` files:
+
+| Example                                                                                                | Description                                    |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| [`simple_pipeline.mmd`](https://github.com/seqeralabs/nf-metro/blob/main/examples/simple_pipeline.mmd) | Minimal two-line pipeline with no sections     |
+| [`rnaseq_auto.mmd`](https://github.com/seqeralabs/nf-metro/blob/main/examples/rnaseq_auto.mmd)         | nf-core/rnaseq with fully auto-inferred layout |
+| [`rnaseq_sections.mmd`](https://github.com/seqeralabs/nf-metro/blob/main/examples/rnaseq_sections.mmd) | nf-core/rnaseq with manual grid overrides      |
+
+### Topology gallery
+
+[`examples/topologies/`](https://github.com/seqeralabs/nf-metro/tree/main/examples/topologies) collects the layout patterns the engine is tested against. See the [topology README](https://github.com/seqeralabs/nf-metro/blob/main/examples/topologies/README.md) for descriptions and rendered previews, or browse the [online gallery](https://seqeralabs.github.io/nf-metro/latest/gallery/).
+
+A few highlights:
+
+|                                                                                                                  |                                                                                                                            |                                                                                                                        |
+| :--------------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------: |
+|                                                 **Wide Fan-Out**                                                 |                                                    **Section Diamond**                                                     |                                                  **Variant Calling**                                                   |
+| ![Wide Fan-Out](https://raw.githubusercontent.com/seqeralabs/nf-metro/main/examples/topologies/wide_fan_out.png) |   ![Section Diamond](https://raw.githubusercontent.com/seqeralabs/nf-metro/main/examples/topologies/section_diamond.png)   | ![Variant Calling](https://raw.githubusercontent.com/seqeralabs/nf-metro/main/examples/topologies/variant_calling.png) |
+|                                               **Fold Serpentine**                                                |                                                   **Multi-Line Bundle**                                                    |                                                    **RNA-seq Lite**                                                    |
+|  ![Fold Double](https://raw.githubusercontent.com/seqeralabs/nf-metro/main/examples/topologies/fold_double.png)  | ![Multi-Line Bundle](https://raw.githubusercontent.com/seqeralabs/nf-metro/main/examples/topologies/multi_line_bundle.png) |    ![RNA-seq Lite](https://raw.githubusercontent.com/seqeralabs/nf-metro/main/examples/topologies/rnaseq_lite.png)     |
 
 ## Python API
 
@@ -434,4 +170,4 @@ See the [Contributing guide](https://seqeralabs.github.io/nf-metro/latest/contri
 
 ## License
 
-[MIT](LICENSE)
+[MIT](https://github.com/seqeralabs/nf-metro/blob/main/LICENSE)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -336,6 +336,13 @@ Validate a rendered SVG's embedded manifest against the [manifest JSON Schema](/
 nf-metro validate-svg [OPTIONS] SVG_FILE
 ```
 
+Schema validation needs `jsonschema`, which is not a runtime dependency. It
+ships in the `validate` extra:
+
+```bash frame="terminal"
+pip install "nf-metro[validate]"
+```
+
 | Option       | Default | Description                                                                                                                                                                                                                                             |
 | ------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--geometry` | off     | Also run the artifact-only render-geometry guards on the drawn ink (label strikes and non-consumer marker crossings), not just the manifest schema. The offset-collapse check needs the engine's assigned offsets and runs only via `render --validate` |

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -15,7 +15,7 @@ cd nf-metro
 pip install -e ".[dev]"
 ```
 
-Required Python: 3.11+. Dependencies: `click`, `drawsvg`, `networkx`, `pillow`. Dev extras add `pytest`, `ruff`, `mypy`.
+Required Python: 3.11+. Dependencies: `click`, `drawsvg`, `lark`, `networkx`, `pillow`. Dev extras add `pytest`, `ruff`, `mypy`.
 
 A plain clone also fetches the `gh-pages` branch, an orphan branch carrying the built docs site and every open PR's render preview - work only ever happens on `main`, so if you don't need that history, clone single-branch:
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -127,7 +127,8 @@ required fields are exactly the [minimum-conforming](#minimum-to-be-conforming)
 set.
 
 To validate an SVG, read its manifest out and check it against the schema. In
-Python (`pip install jsonschema` - it is not an nf-metro runtime dependency):
+Python (`jsonschema` is not an nf-metro runtime dependency; `pip install
+"nf-metro[validate]"` adds it):
 
 ```python
 import jsonschema
@@ -146,8 +147,8 @@ nf-metro validate-svg pipeline.svg
 # Valid: 42 nodes, schema version 1.0   (exits non-zero if it doesn't conform)
 ```
 
-(`validate-svg` uses `jsonschema`, which is not a runtime dependency; install it
-with `pip install "nf-metro[validate]"` if it isn't already present.)
+(`validate-svg` needs the same package, so `pip install "nf-metro[validate]"`
+covers it too.)
 
 Add `--geometry` to also check the _drawn_ picture, not just the schema: it flags
 a route drawn through a station's label or marker (rail interchanges excepted).

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -146,8 +146,8 @@ nf-metro validate-svg pipeline.svg
 # Valid: 42 nodes, schema version 1.0   (exits non-zero if it doesn't conform)
 ```
 
-(`validate-svg` uses `jsonschema`; install it with `pip install jsonschema` if it
-isn't already present.)
+(`validate-svg` uses `jsonschema`, which is not a runtime dependency; install it
+with `pip install "nf-metro[validate]"` if it isn't already present.)
 
 Add `--geometry` to also check the _drawn_ picture, not just the schema: it flags
 a route drawn through a station's label or marker (rail interchanges excepted).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
     "mypy>=1.8",
     "types-networkx",
     "numpy<2.5",
-    "jsonschema>=4.0",
+    "nf-metro[validate]",
     "cairosvg==2.9.0",
 ]
 # Docs site is Astro/Starlight (see website/package.json). This extra only provides
@@ -157,9 +157,10 @@ ignore_missing_imports = false
 strict_optional = true
 disallow_any_generics = true
 
-# drawsvg ships no type information; jsonschema is an optional, test-only
-# dependency imported lazily by `nf-metro validate-svg`. Everything else (click,
-# Pillow, networkx via types-networkx) is typed once the package is installed.
+# drawsvg ships no type information; jsonschema is an optional dependency (the
+# `validate` extra) imported lazily by `nf-metro validate-svg`. Everything else
+# (click, Pillow, networkx via types-networkx) is typed once the package is
+# installed.
 [[tool.mypy.overrides]]
 module = ["drawsvg", "jsonschema"]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/pinin4fjords/nf-metro"
-Repository = "https://github.com/pinin4fjords/nf-metro"
-Issues = "https://github.com/pinin4fjords/nf-metro/issues"
+Homepage = "https://github.com/seqeralabs/nf-metro"
+Documentation = "https://seqeralabs.github.io/nf-metro/latest/"
+Repository = "https://github.com/seqeralabs/nf-metro"
+Issues = "https://github.com/seqeralabs/nf-metro/issues"
 
 [project.scripts]
 nf-metro = "nf_metro.cli:cli"
@@ -72,6 +73,11 @@ docs = [
 font = [
     "fonttools[woff]>=4.0",
 ]
+# `nf-metro validate-svg` validates an SVG's embedded manifest against a Draft
+# 2020-12 schema, which jsonschema only implements from 4.0.
+validate = [
+    "jsonschema>=4.0",
+]
 
 # The skill self-check needs pyyaml for the gallery corpus map, and a tokenizer to
 # gate SKILL.md against Claude Code's post-compaction re-attachment cap. `anthropic`
@@ -85,9 +91,14 @@ skill-checks = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nf_metro"]
-# The candidate executor is a development harness with no importer in the
-# package: it is driven from the test suite and a source checkout only.
-exclude = ["src/nf_metro/candidate_executor.py"]
+# Both live under the package directory but have no importer or reader at
+# runtime: the candidate executor is a harness driven from the test suite and a
+# source checkout, and CONTRACT.md is the layout pipeline's stage-by-stage
+# design record, cited only from comments and the test suite.
+exclude = [
+  "src/nf_metro/candidate_executor.py",
+  "src/nf_metro/layout/CONTRACT.md",
+]
 
 [tool.hatch.build.targets.sdist]
 # Ship what is needed to build and audit the package: src, packaging metadata,

--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -297,7 +297,7 @@ HTML_TEMPLATE = """\
 <details class="intro">
 <summary>What is this page?</summary>
 <p>
-<a href="https://github.com/pinin4fjords/nf-metro">nf-metro</a>
+<a href="https://github.com/seqeralabs/nf-metro">nf-metro</a>
 generates metro-map-style SVG diagrams from Mermaid graph definitions.
 This page is automatically generated for every pull request and shows
 <strong>only the renders that changed</strong> compared to the

--- a/src/nf_metro/live/state_schema.json
+++ b/src/nf_metro/live/state_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://pinin4fjords.github.io/nf-metro/state.schema.json",
+  "$id": "https://seqeralabs.github.io/nf-metro/state.schema.json",
   "title": "Live state snapshot",
   "description": "The runtime progress snapshot served by nf-metro's live server (GET /state, and each Server-Sent Event on /stream) - the state half of the live-diagram contract, paired with the diagram manifest (nf_metro/manifest/schema.json). A node's key here is the manifest's node.id / data-node-id join key. Tool-neutral and experimental (pre-1.0): unlike the manifest, no version field travels inside the snapshot itself, since it is a live response rather than a durable artifact; this schema file is versioned 1.0 and evolves under the same rule as the manifest - consumers MUST ignore unknown fields, and additive fields keep the same major version.",
   "type": "object",

--- a/src/nf_metro/manifest/schema.json
+++ b/src/nf_metro/manifest/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://pinin4fjords.github.io/nf-metro/manifest.schema.json",
+  "$id": "https://seqeralabs.github.io/nf-metro/manifest.schema.json",
   "title": "Diagram manifest",
   "description": "A self-describing, addressable SVG diagram manifest, embedded in a <metadata id=\"diagram-manifest\"> element. Tool-neutral and experimental (pre-1.0): the schema may change without a version bump until declared stable. Consumers MUST ignore unknown fields, so additional properties are permitted everywhere.",
   "type": "object",

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -105,7 +105,7 @@ def _check_unsupported_input(text: str) -> None:
             "without %%metro directives). Use 'nf-metro convert' to "
             "convert it to nf-metro format first, or pass "
             "'--from-nextflow' to 'nf-metro render'.\n\n"
-            "See: https://pinin4fjords.github.io/nf-metro/latest/nextflow/"
+            "See: https://seqeralabs.github.io/nf-metro/latest/nextflow/"
         )
 
     if has_flowchart:
@@ -113,7 +113,7 @@ def _check_unsupported_input(text: str) -> None:
             "Mermaid 'flowchart' syntax is not supported. "
             "Use 'graph LR' with %%metro directives instead.\n\n"
             "See the guide: "
-            "https://pinin4fjords.github.io/nf-metro/latest/guide/"
+            "https://seqeralabs.github.io/nf-metro/latest/guide/"
         )
 
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -9633,7 +9633,7 @@ def test_debug_grid_overlay_boundaries_outside_section_bboxes(fixture):
     segment for that column is dropped.  This test asserts no emitted
     segment cuts any section bbox in the rows/columns it joins.
 
-    Bug: https://github.com/pinin4fjords/nf-metro/issues/316
+    Bug: https://github.com/seqeralabs/nf-metro/issues/316
     """
     from nf_metro.render.svg import (
         _compute_col_boundary_xs,

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,28 @@
+"""Packaging invariants: the version a user sees must be the version shipped."""
+
+import tomllib
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+import pytest
+
+import nf_metro
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _declared_version() -> str:
+    with (ROOT / "pyproject.toml").open("rb") as handle:
+        return str(tomllib.load(handle)["project"]["version"])
+
+
+def test_module_version_matches_pyproject():
+    assert nf_metro.__version__ == _declared_version()
+
+
+def test_installed_distribution_version_matches_module_version():
+    try:
+        installed = version("nf-metro")
+    except PackageNotFoundError:
+        pytest.skip("nf-metro is not installed in this environment")
+    assert installed == nf_metro.__version__

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -516,7 +516,7 @@ def test_subgraph_without_display_name():
 def test_empty_section_removed():
     """Subgraphs with only edges (no node definitions) are removed.
 
-    Regression test for https://github.com/pinin4fjords/nf-metro/issues/51.
+    Regression test for https://github.com/seqeralabs/nf-metro/issues/51.
     When nodes are defined outside a subgraph but edges referencing them
     appear inside the subgraph, the section has no stations. The parser
     should remove it and fall back to flat layout instead of crashing.


### PR DESCRIPTION
Pre-release cleanup of the surfaces someone meets before they ever look at the layout engine: the wheel's metadata, the PyPI landing page, and the CI that ships the artefact.

## Packaging metadata

- `[project.urls]` pointed `Homepage`/`Repository`/`Issues` at `github.com/pinin4fjords/nf-metro`, which is baked into the wheel's METADATA, so the PyPI sidebar advertised a personal-username redirect. All three now point at `seqeralabs`, plus a new `Documentation` entry for `https://seqeralabs.github.io/nf-metro/latest/`.
- New `validate` extra (`jsonschema>=4.0`), referenced from the `dev` extra so there is a single floor to keep in step (hatchling flattens the self-reference at build time, so the wheel metadata still carries a plain `jsonschema>=4.0` for `extra == "dev"`). `nf-metro validate-svg` is documented but `jsonschema` lived only in `dev`, so the command had no supported install path: in a clean venv it exited 1 with `validate-svg needs the jsonschema package`. The floor is the version that first implements Draft 2020-12, which is what the manifest schema declares.
- `src/nf_metro/layout/CONTRACT.md` is excluded from the wheel. At 2,465 lines / 155 KB uncompressed (51 KB deflated) it was the largest single file in the distribution. Nothing reads it at runtime: every reference is a comment or a docstring, and the only file readers are `tests/test_phase_state_registry.py` and `tests/test_contract_lifecycle.py`, neither of which is shipped. It stays in the sdist, which ships `src/` for auditing.

## Shipped error messages

`parser/mermaid.py` told users to see `pinin4fjords.github.io/nf-metro/latest/{nextflow,guide}/`, both 404. These two messages fire exactly when someone feeds in raw Nextflow DAG output, which is a likely first contact. Repointed at the `seqeralabs.github.io` equivalents (both 200).

Other `pinin4fjords` occurrences: the two JSON Schema `$id`s (shipped in the wheel, no resolver or test depends on them), the render-diff page footer and two test docstrings citing issue URLs are all repointed. Left alone: `docs/releases/*` and `CHANGELOG.md` (release history), the author links in `docs/credits.md` and `PageFrame.astro` (a personal profile, not the repo), and the `pinin4fjords:simplify` skill name in `.claude/`.

## README

README is the PyPI landing page and its reference tables had drifted badly: the `render` option table was missing nine options, offered three `--theme` values where the CLI takes seven, and showed `INPUT_FILE` for a command that now takes `INPUT_FILES...`; the directive table listed 24 of the 48 real directives; `style:` was documented as "`dark`, `light`" with no mention of `nfcore` or `seqera`; `direction:` omitted `BT`; and `%%metro line:` was shown with four fields where the parser takes five.

`docs/cli.md` and `docs/guide.mdx` are accurate and complete, so rather than re-synchronising two copies the README now keeps the quickstart, the feature tour, the interactive-HTML / live-progress / manifest sections and the examples, and links out for every reference table. What is left cannot go stale: nothing enumerates a set of valid values or a count of anything. The quickstart now writes the map it renders, rather than naming a path under `examples/`, which no wheel ships: the first command a reader runs works from a bare `pip install nf-metro` with no checkout.

Its relative links and images are also absolutised against `github.com/seqeralabs/nf-metro`, matching what the hero images already did, so the highlights grid and the example links resolve on PyPI instead of rendering as broken placeholders. All 30 URLs in the file return 200.

One more docs-accuracy fix while in the area: `docs/contributing.mdx` listed the runtime dependencies without `lark`, which the parser has depended on since the Lark grammar landed.

## Version and artefact guards

- `tests/test_packaging.py` pins `nf_metro.__version__` to the `pyproject.toml` version, and to `importlib.metadata.version("nf-metro")` when the distribution is installed. `cli.py` sources `--version` from `__init__`, so a half-bump would otherwise ship a wheel whose `--version` lies.
- `publish.yml` gains one step: after `python -m build`, fail if the release tag does not match the built wheel's version. PyPI takes the version from the artefact, not the tag, so a tag cut against an unbumped tree would publish under the previous version. A wheel filename carries the PEP 427 normalised version, so the two sides are compared as parsed versions rather than as strings: a leading `v` is tolerated, and a hyphenated prerelease tag (`v1.2.0-rc1` against a `1.2.0rc1` wheel) matches instead of failing a legitimate release. More than one wheel in `dist/` is an error rather than a silently stripped filename suffix. The workflow is otherwise untouched.
- New `wheel-smoke` job in `ci.yml`: one job, one Python version, gated behind `lint`/`format`. It builds the wheel, runs `twine check --strict`, asserts the wheel still ships its nine non-Python package data files and no longer ships `CONTRACT.md`, then installs the wheel into a clean venv and renders an example with the working directory outside the checkout. That combination is what catches an import that only resolved because `src/` was on the path, or a resource addressed by a repo-relative path. Every other CI job installs `-e ".[dev,font]"`, so nothing previously exercised the artefact that gets published.

The smoke test renders `examples/simple_pipeline.mmd`: it has no `%%metro logo:` directive, so it does not depend on the shipped-example logo paths that only resolve from the repo root.

## Verification

Built from this branch into a scratch directory, installed into a clean venv, and run from a directory outside the repo:

```
$ twine check --strict dist/*
Checking dist/nf_metro-1.1.0-py3-none-any.whl: PASSED
Checking dist/nf_metro-1.1.0.tar.gz: PASSED

$ cd /tmp/.../outside2
$ nf-metro --version
nf-metro, version 1.1.0
$ nf-metro render .../examples/simple_pipeline.mmd -o smoke.svg
Rendered 6 stations, 7 edges, 2 lines -> smoke.svg

$ python -c "from importlib.metadata import metadata; print(metadata('nf-metro').get_all('Project-URL'))"
Homepage, https://github.com/seqeralabs/nf-metro
Documentation, https://seqeralabs.github.io/nf-metro/latest/
Repository, https://github.com/seqeralabs/nf-metro
Issues, https://github.com/seqeralabs/nf-metro/issues
```

The README quickstart was then run verbatim, in an empty directory with nothing but the wheel installed:

```
$ cat > pipeline.mmd <<'EOF' ... EOF
$ nf-metro render pipeline.mmd -o pipeline.svg
Rendered 4 stations, 4 edges, 2 lines -> pipeline.svg
$ nf-metro validate pipeline.mmd
Valid: 4 stations, 4 edges, 2 lines, 0 sections
$ nf-metro info pipeline.mmd
Title: Simple Pipeline / Stations: 4 / Edges: 4 / Lines: 2
```

Wheel contents: `py.typed`, `fonts/Inter-Regular.woff2`, `fonts/Inter-Bold.woff2`, `fonts/LICENSE.txt`, `live/state_schema.json`, `manifest/schema.json`, `render/driver.js`, `render/inline.html` and `render/standalone.html` all present; zero occurrences of `CONTRACT.md`.

The `validate` extra, from the same clean venv:

```
$ nf-metro validate-svg smoke.svg
Error: validate-svg needs the jsonschema package: pip install jsonschema
$ pip install "nf-metro[validate]" --find-links dist
$ nf-metro validate-svg smoke.svg
Valid: 6 nodes, schema version 1.0
```

Lint and tests: `ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy`, `prek run --all-files` (including the prettier hook) all pass. `pytest tests/test_packaging.py tests/test_ci_workflows.py tests/test_parser.py tests/test_parser_grammar.py tests/test_manifest.py tests/test_manifest_standalone.py tests/test_live_state_schema.py tests/test_convert.py` passes (1037 + 15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


