### PR TITLE
fix(render): honour theme.terminus_font_color so inactive icon labels mute

### DIFF
--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -297,7 +297,11 @@ def station_is_muted(
 
 
 TERMINUS_FONT_COLOR: str = "#000000"
-"""Font color for terminus file icon labels."""
+"""Font color for terminus file icon labels.
+
+The icon body carries a light fill in every theme and mode, so this ink stays
+dark rather than pairing through ``light-dark()``.
+"""
 
 # ---------------------------------------------------------------------------
 # Debug overlay colors

--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -76,7 +76,9 @@ class Theme:
     terminus_stroke_width: float = 1.5
     terminus_corner_radius: float = 2.0
     terminus_font_size: float = 7.5
-    terminus_font_color: str = ""  # empty = inherit label_color
+    # Ink for the label inside the icon body; empty takes TERMINUS_FONT_COLOR.
+    # label_color tracks the map background, which this label never sits on.
+    terminus_font_color: str = ""
     # Bridge glyph at non-merging line crossings
     bridge_glyph: bool = True
     # Interior fill for "open" markers (%%metro marker: ... | open). Empty

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -4429,7 +4429,7 @@ def _render_terminus_icons(
             corner_radius=theme.terminus_corner_radius,
             label=label,
             font_size=theme.terminus_font_size,
-            font_color=TERMINUS_FONT_COLOR,
+            font_color=theme.terminus_font_color or TERMINUS_FONT_COLOR,
             font_family=theme.label_font_family,
         )
 

--- a/tests/test_inactive_lines.py
+++ b/tests/test_inactive_lines.py
@@ -9,6 +9,7 @@ from nf_metro.errors import NfMetroError
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render.constants import (
     FALLBACK_LINE_COLOR,
+    TERMINUS_FONT_COLOR,
     effective_line_color,
     station_is_muted,
 )
@@ -55,6 +56,18 @@ def _label_fill_by_station(svg):
         if sid is not None and "label" in cls:
             out[sid] = el.get("fill")
     return out
+
+
+def _icon_label_fill(svg, station_id, label):
+    """Fill of the ``label`` text drawn inside ``station_id``'s terminus icon."""
+    root = ET.fromstring(svg)
+    for group in root.iter():
+        if group.get("data-node-id") != station_id:
+            continue
+        for el in group.iter():
+            if el.tag.endswith("text") and el.text == label:
+                return el.get("fill")
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -142,6 +155,23 @@ def test_muted_station_keeps_fill():
         if el.tag.endswith("rect") and el.get("data-station-id") == "x":
             # Fill is the theme station fill, not the muted grey.
             assert el.get("fill") == NFCORE_DARK_THEME.station_fill
+
+
+TERMINUS_MAP = (
+    "%%metro line: a | Line A | #ff0000 | solid | inactive\n"
+    "%%metro line: b | Line B | #0000ff\n"
+    "%%metro file: a_out | SF\n"
+    "%%metro file: b_out | BAM\n"
+    "graph LR\n"
+    "    x[X] -->|a| a_out[ ]\n"
+    "    x -->|b| b_out[ ]\n"
+)
+
+
+def test_inactive_only_terminus_icon_label_muted():
+    svg = _svg(TERMINUS_MAP)
+    assert _icon_label_fill(svg, "a_out", "SF") == MUTED
+    assert _icon_label_fill(svg, "b_out", "BAM") == TERMINUS_FONT_COLOR
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`Theme.terminus_font_color` was declared but never read. The format label inside a terminus (file/dir) icon took the module constant `TERMINUS_FONT_COLOR` directly, so the muted-line override theme built for inactive lines never reached it: an icon on an inactive-only line rendered a greyed body, a greyed connector and a greyed caption below, with a full-strength black label inside.

The render site now reads `theme.terminus_font_color`, falling back to `TERMINUS_FONT_COLOR` when it is empty, the same shape as the sibling `terminus_fill` / `terminus_stroke` fields on the same element.

## The declared fallback

The field claimed `empty = inherit label_color`. It cannot: `label_color` is ink for text on the map background (`#e0e0e0` in nfcore dark, `#e0d9f7` in seqera dark), while this label sits on the icon body. The body fill is `terminus_fill or station_fill`, no theme sets `terminus_fill`, and `station_fill` is `#ffffff` in every theme and mode, so inheriting `label_color` would put pale grey on white. The declaration now states the real fallback.

For the same reason the constant stays a plain `#000000` with no `light-dark()` pair: the surface behind it does not change with the viewer's `color-scheme`. The constant's docstring now records that.

## Scope

The icon-body label is the only element affected. The name caption below an icon already muted through `theme.label_color`; a banner label keeps its own white-on-dark pair.

Rendering the whole shipped `.mmd` corpus (397 maps) before and after gives byte-identical SVG for all of them: `examples/inactive_lines.mmd` is the only shipped map with an inactive line and it carries no terminus icons. Rendering `examples/differentialabundance.mmd` with `--inactive-lines affy,maxquant` changes exactly the two icon labels on those lines (`CEL`, `TSV`) in both modes and nothing else.

`tests/test_inactive_lines.py` gains a lock: an inactive-only terminus icon label renders muted grey while an active one keeps the icon ink.