### PR TITLE
test: close gaps where a test could not fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,5 @@ jobs:
           cache-dependency-path: pyproject.toml
       - run: pip install -e ".[dev,font]"
       - run: pytest -n 0 tests/test_routing_gate_coverage.py
+        env:
+          NF_METRO_REQUIRE_GATE_COVERAGE: "1"

--- a/tests/test_bridge_glyph.py
+++ b/tests/test_bridge_glyph.py
@@ -576,24 +576,39 @@ def test_issue484_same_colour_crossover_is_bridged():
     """issue #484: a horizontal bam run crosses a vertical bam drop below the
     Small-variant/Phasing sections - a genuine same-colour crossover whose legs
     head to separate, never-reconverging destinations.  A bridge must fire."""
-    path = Path(__file__).parent.parent / "issue484.mmd"
-    if not path.exists():
-        pytest.skip("issue484.mmd repro fixture not present")
-    _, routes, _, bridges = _bridges(path)
-    by_id = {id(r): r for r in routes}
+    path = EXAMPLES_DIR / "longread_variant_calling.mmd"
+    _, routes, polylines, bridges = _bridges(path)
+    by_id = {id(r): (r, poly) for r, poly in zip(routes, polylines)}
     bam_breaks = [
-        (bk, by_id[rid])
+        (bk, by_id[rid][0])
         for rid, breaks in bridges.items()
         for bk in breaks
-        if by_id[rid].line_id == "bam"
+        if by_id[rid][0].line_id == "bam"
     ]
-    assert bam_breaks, "expected a bam crossover bridge in issue484"
-    # The documented crossing is at (~1616, 263); the gap is centred there.
-    assert any(
-        abs((bk.cut_a[0] + bk.cut_b[0]) / 2 - 1616) < 30
-        and abs((bk.cut_a[1] + bk.cut_b[1]) / 2 - 263) < 30
-        for bk, _ in bam_breaks
-    )
+    assert bam_breaks, f"expected a bam crossover bridge in {path.stem}"
+    # A gap only reads as one line passing over another if it is centred on the
+    # crossing, so its midpoint must land on the bam run passing underneath.
+    bam_polylines = [
+        poly for route, poly in zip(routes, polylines) if route.line_id == "bam"
+    ]
+    for bk, route in bam_breaks:
+        midpoint = (
+            (bk.cut_a[0] + bk.cut_b[0]) / 2,
+            (bk.cut_a[1] + bk.cut_b[1]) / 2,
+        )
+        crossed = [
+            (a, b)
+            for poly in bam_polylines
+            if poly is not by_id[id(route)][1]
+            for a, b in zip(poly, poly[1:])
+            if min(a[0], b[0]) - 1 <= midpoint[0] <= max(a[0], b[0]) + 1
+            and min(a[1], b[1]) - 1 <= midpoint[1] <= max(a[1], b[1]) + 1
+            and _perp_distance(midpoint, a, b) <= 1.0
+        ]
+        assert crossed, (
+            f"bam gap centred at {midpoint} on "
+            f"{route.edge.source}->{route.edge.target} sits on no other bam run"
+        )
 
 
 def test_issue1322_forked_arms_recross_far_from_fork_is_bridged():

--- a/tests/test_bridge_glyph.py
+++ b/tests/test_bridge_glyph.py
@@ -572,12 +572,77 @@ def test_same_line_independent_legs_are_a_crossover():
     )
 
 
+def _segment_crossing(a, b, c, d):
+    """Where segments ``a``-``b`` and ``c``-``d`` cross, or ``None``.
+
+    Parallel segments are excluded however far they overlap: two runs sharing a
+    channel have no single point where one passes over the other, so a gap on
+    such an overlap shows the reader nothing.  The crossing must also be
+    interior to both segments, since a shared endpoint is a join, not a
+    crossover.
+    """
+    run = (b[0] - a[0], b[1] - a[1])
+    other = (d[0] - c[0], d[1] - c[1])
+    denominator = run[0] * other[1] - run[1] * other[0]
+    if abs(denominator) < 1e-9:
+        return None
+    along = ((c[0] - a[0]) * other[1] - (c[1] - a[1]) * other[0]) / denominator
+    across = ((c[0] - a[0]) * run[1] - (c[1] - a[1]) * run[0]) / denominator
+    if not (0 < along < 1 and 0 < across < 1):
+        return None
+    return (a[0] + along * run[0], a[1] + along * run[1])
+
+
+def _same_line_crossings(routes, polylines, line_id):
+    """Every point at which two *line_id* runs cross, keyed by rounded point.
+
+    Valued by the sections every leg crossing there heads into, which name a
+    crossover independently of where global compaction has since put it.  One
+    crossing can involve more than two legs, because a drop shared by several
+    downstream sections is drawn as one channel carrying each of them.
+    """
+    drawn = [(r, p) for r, p in zip(routes, polylines) if r.line_id == line_id]
+    crossings: dict[tuple[float, float], set[str]] = {}
+    for index, (route_a, poly_a) in enumerate(drawn):
+        for route_b, poly_b in drawn[index + 1 :]:
+            for a, b in zip(poly_a, poly_a[1:]):
+                for c, d in zip(poly_b, poly_b[1:]):
+                    point = _segment_crossing(a, b, c, d)
+                    if point is None:
+                        continue
+                    key = (round(point[0], 1), round(point[1], 1))
+                    crossings.setdefault(key, set()).update(
+                        {
+                            route_a.edge.target.split("__")[0],
+                            route_b.edge.target.split("__")[0],
+                        }
+                    )
+    return crossings
+
+
 def test_issue484_same_colour_crossover_is_bridged():
     """issue #484: a horizontal bam run crosses a vertical bam drop below the
     Small-variant/Phasing sections - a genuine same-colour crossover whose legs
-    head to separate, never-reconverging destinations.  A bridge must fire."""
+    head to separate, never-reconverging destinations.  A bridge must fire.
+
+    The map holds exactly one such crossover, so requiring the sole bam gap to
+    sit on the sole bam crossing pins the gap to that one place without naming
+    a coordinate that moves whenever the map compacts.
+    """
     path = EXAMPLES_DIR / "longread_variant_calling.mmd"
     _, routes, polylines, bridges = _bridges(path)
+
+    crossings = _same_line_crossings(routes, polylines, "bam")
+    assert len(crossings) == 1, (
+        f"expected the one documented bam crossover in {path.stem}, found "
+        f"{len(crossings)}: {crossings}"
+    )
+    [(crossing_point, crossed_sections)] = crossings.items()
+    assert {"tr_calling", "structural_variants"} <= crossed_sections, (
+        f"the bam crossover involves legs into {crossed_sections}, which does "
+        f"not include the documented tr_calling / structural_variants pair"
+    )
+
     by_id = {id(r): (r, poly) for r, poly in zip(routes, polylines)}
     bam_breaks = [
         (bk, by_id[rid][0])
@@ -585,30 +650,24 @@ def test_issue484_same_colour_crossover_is_bridged():
         for bk in breaks
         if by_id[rid][0].line_id == "bam"
     ]
-    assert bam_breaks, f"expected a bam crossover bridge in {path.stem}"
-    # A gap only reads as one line passing over another if it is centred on the
-    # crossing, so its midpoint must land on the bam run passing underneath.
-    bam_polylines = [
-        poly for route, poly in zip(routes, polylines) if route.line_id == "bam"
-    ]
-    for bk, route in bam_breaks:
-        midpoint = (
-            (bk.cut_a[0] + bk.cut_b[0]) / 2,
-            (bk.cut_a[1] + bk.cut_b[1]) / 2,
-        )
-        crossed = [
-            (a, b)
-            for poly in bam_polylines
-            if poly is not by_id[id(route)][1]
-            for a, b in zip(poly, poly[1:])
-            if min(a[0], b[0]) - 1 <= midpoint[0] <= max(a[0], b[0]) + 1
-            and min(a[1], b[1]) - 1 <= midpoint[1] <= max(a[1], b[1]) + 1
-            and _perp_distance(midpoint, a, b) <= 1.0
-        ]
-        assert crossed, (
-            f"bam gap centred at {midpoint} on "
-            f"{route.edge.source}->{route.edge.target} sits on no other bam run"
-        )
+    assert len(bam_breaks) == 1, (
+        f"expected exactly one bam gap in {path.stem}, got "
+        f"{[(r.edge.source, r.edge.target) for _, r in bam_breaks]}"
+    )
+    bk, route = bam_breaks[0]
+    midpoint = (
+        (bk.cut_a[0] + bk.cut_b[0]) / 2,
+        (bk.cut_a[1] + bk.cut_b[1]) / 2,
+    )
+    assert midpoint == pytest.approx(crossing_point, abs=1.0), (
+        f"bam gap on {route.edge.source}->{route.edge.target} is centred at "
+        f"{midpoint}, not on the crossing at {crossing_point}"
+    )
+    assert route.edge.target.split("__")[0] in crossed_sections, (
+        f"the bam gap breaks the leg into "
+        f"{route.edge.target.split('__')[0]}, which is not one of the two "
+        f"crossing legs {set(crossed_sections)}"
+    )
 
 
 def test_issue1322_forked_arms_recross_far_from_fork_is_bridged():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -57,6 +57,22 @@ def test_test_matrix_uses_committed_timings_and_reports_slow_tests():
     assert "--durations=25" in job
 
 
+GATE_MODULE = "tests/test_routing_gate_coverage.py"
+GATE_REQUIRE_ENV = 'NF_METRO_REQUIRE_GATE_COVERAGE: "1"'
+STEP_HEADER = re.compile(r"^      - ", re.MULTILINE)
+
+
+def _steps(job: str) -> list[str]:
+    """The job's steps, each spanning its own ``- `` marker to the next.
+
+    Assertions about a step's ``env:`` or its arguments have to be made against
+    the step itself: matched against the whole job they also hold when the key
+    sits on a neighbouring step, where it has no effect on the command.
+    """
+    starts = [match.start() for match in STEP_HEADER.finditer(job)]
+    return [job[a:b] for a, b in zip(starts, [*starts[1:], len(job)])]
+
+
 def test_routing_gate_job_pins_the_baseline_interpreter_and_demands_a_run():
     """The gate ratchet's job must be unable to pass without running it.
 
@@ -64,18 +80,44 @@ def test_routing_gate_job_pins_the_baseline_interpreter_and_demands_a_run():
     and is ``--ignore``d in the matrix, so a pin that drifted from
     ``BASELINE_PYTHON`` would leave the two-sided ratchet reporting success
     from a run of nothing.  ``NF_METRO_REQUIRE_GATE_COVERAGE`` turns that skip
-    into a failure for this job alone.
+    into a failure, and only for the step that invokes the ratchet, so the
+    variable is required on that step rather than anywhere in the job.
     """
     sys.path.insert(0, str(ROOT / "scripts"))
     import routing_gate_coverage
 
     major, minor = routing_gate_coverage.BASELINE_PYTHON
-    job = _jobs(WORKFLOWS / "ci.yml")["routing-gates"]
-    assert f'python-version: "{major}.{minor}"' in job
-    assert 'NF_METRO_REQUIRE_GATE_COVERAGE: "1"' in job
-    assert (
-        "--ignore=tests/test_routing_gate_coverage.py"
-        in _jobs(WORKFLOWS / "ci.yml")["test"]
+    jobs = _jobs(WORKFLOWS / "ci.yml")
+    job = jobs["routing-gates"]
+
+    setup = [step for step in _steps(job) if "uses: actions/setup-python" in step]
+    assert len(setup) == 1, f"expected one setup-python step, got {len(setup)}"
+    assert f'python-version: "{major}.{minor}"' in setup[0], (
+        f"routing-gates must pin CPython {major}.{minor} to match "
+        f"BASELINE_PYTHON, or the module it runs skips"
+    )
+
+    invocations = [
+        step
+        for step in _steps(job)
+        if re.search(r"^      - run: .*\bpytest\b", step, re.MULTILINE)
+    ]
+    assert len(invocations) == 1, (
+        f"expected exactly one pytest step in routing-gates, got {len(invocations)}"
+    )
+    step = invocations[0]
+    assert GATE_MODULE in step, (
+        f"the routing-gates pytest step must invoke {GATE_MODULE}; it runs: {step!r}"
+    )
+    assert GATE_REQUIRE_ENV in step, (
+        f"{GATE_REQUIRE_ENV} must be set on the step that invokes {GATE_MODULE}, "
+        f"where it can turn that module's interpreter skip into a failure; "
+        f"the step is: {step!r}"
+    )
+
+    assert f"--ignore={GATE_MODULE}" in jobs["test"], (
+        f"the matrix must keep ignoring {GATE_MODULE}, which is the premise "
+        f"that routing-gates is its only run"
     )
 
 

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,6 +1,7 @@
 """Repository invariants for GitHub Actions resource usage."""
 
 import re
+import sys
 from pathlib import Path
 
 import pytest
@@ -54,6 +55,28 @@ def test_test_matrix_uses_committed_timings_and_reports_slow_tests():
     assert "fail-fast: true" in job
     assert "--splitting-algorithm least_duration" in job
     assert "--durations=25" in job
+
+
+def test_routing_gate_job_pins_the_baseline_interpreter_and_demands_a_run():
+    """The gate ratchet's job must be unable to pass without running it.
+
+    ``tests/test_routing_gate_coverage.py`` skips off the baseline interpreter
+    and is ``--ignore``d in the matrix, so a pin that drifted from
+    ``BASELINE_PYTHON`` would leave the two-sided ratchet reporting success
+    from a run of nothing.  ``NF_METRO_REQUIRE_GATE_COVERAGE`` turns that skip
+    into a failure for this job alone.
+    """
+    sys.path.insert(0, str(ROOT / "scripts"))
+    import routing_gate_coverage
+
+    major, minor = routing_gate_coverage.BASELINE_PYTHON
+    job = _jobs(WORKFLOWS / "ci.yml")["routing-gates"]
+    assert f'python-version: "{major}.{minor}"' in job
+    assert 'NF_METRO_REQUIRE_GATE_COVERAGE: "1"' in job
+    assert (
+        "--ignore=tests/test_routing_gate_coverage.py"
+        in _jobs(WORKFLOWS / "ci.yml")["test"]
+    )
 
 
 def test_render_diff_runs_independently_and_uses_content_cache_key():

--- a/tests/test_constant_relations.py
+++ b/tests/test_constant_relations.py
@@ -3,15 +3,14 @@
 ``constants._check_constant_relations`` runs at module import and turns a
 mis-tuned constant (one whose value is only correct relative to another)
 into an immediate, located failure rather than a silent layout regression.
+Importing ``constants`` below is therefore itself that check: a violated
+relation fails collection, so the tests here pin the individual orderings
+and that the checker rejects a violating set of values.
 """
 
 import pytest
 
 from nf_metro.layout import constants as c
-
-
-def test_relations_hold_on_current_values():
-    c._check_constant_relations()
 
 
 def test_coordinate_tolerance_tiers_strictly_ordered():

--- a/tests/test_font_portability.py
+++ b/tests/test_font_portability.py
@@ -23,8 +23,9 @@ from nf_metro.text_metrics import (
 )
 from nf_metro.themes import THEMES
 
-EXAMPLES = list((Path(__file__).parent.parent / "examples").glob("*.mmd"))
-FIXTURE_FILE = EXAMPLES[0] if EXAMPLES else None
+EXAMPLES = sorted((Path(__file__).parent.parent / "examples").glob("*.mmd"))
+assert EXAMPLES, "the examples corpus these render modes are exercised on is missing"
+FIXTURE_FILE = EXAMPLES[0]
 
 
 def _render(fixture: Path, font_portability: str | None = None) -> str:
@@ -37,14 +38,12 @@ def _render(fixture: Path, font_portability: str | None = None) -> str:
 # ── embed ────────────────────────────────────────────────────────────────────
 
 
-@pytest.mark.skipif(FIXTURE_FILE is None, reason="no example fixtures found")
 def test_embed_font_injects_font_face_block() -> None:
     """SVG produced with font_portability='embed' contains an @font-face declaration."""
     svg = _render(FIXTURE_FILE, "embed")
     assert "@font-face" in svg, "Expected @font-face in embedded-font SVG"
 
 
-@pytest.mark.skipif(FIXTURE_FILE is None, reason="no example fixtures found")
 def test_embed_font_contains_base64_data_uri() -> None:
     """The @font-face src must use a data URI (base64-encoded WOFF2), not a URL."""
     svg = _render(FIXTURE_FILE, "embed")
@@ -53,7 +52,6 @@ def test_embed_font_contains_base64_data_uri() -> None:
     )
 
 
-@pytest.mark.skipif(FIXTURE_FILE is None, reason="no example fixtures found")
 @pytest.mark.parametrize("fixture", EXAMPLES, ids=lambda p: p.name)
 def test_embed_font_family_has_generic_fallback(fixture: Path) -> None:
     """Every embedded font-family must end in a generic family so a stripped
@@ -68,7 +66,6 @@ def test_embed_font_family_has_generic_fallback(fixture: Path) -> None:
         )
 
 
-@pytest.mark.skipif(FIXTURE_FILE is None, reason="no example fixtures found")
 def test_plain_render_uses_helvetica() -> None:
     """Default render (font_portability=None) uses the Helvetica font stack."""
     svg = _render(FIXTURE_FILE)
@@ -78,28 +75,24 @@ def test_plain_render_uses_helvetica() -> None:
 # ── paths ────────────────────────────────────────────────────────────────────
 
 
-@pytest.mark.skipif(FIXTURE_FILE is None, reason="no example fixtures found")
 def test_text_to_paths_removes_all_text_elements() -> None:
     """SVG produced with font_portability='paths' must contain no <text> elements."""
     svg = _render(FIXTURE_FILE, "paths")
     assert "<text" not in svg, "paths mode must not leave any <text> elements"
 
 
-@pytest.mark.skipif(FIXTURE_FILE is None, reason="no example fixtures found")
 def test_text_to_paths_produces_path_elements() -> None:
     """paths output must have <path> elements where text was."""
     svg = _render(FIXTURE_FILE, "paths")
     assert svg.count("<path ") > 0, "Expected <path> elements in paths output"
 
 
-@pytest.mark.skipif(FIXTURE_FILE is None, reason="no example fixtures found")
 def test_text_to_paths_no_font_family_attributes() -> None:
     """paths output must not reference any font family."""
     svg = _render(FIXTURE_FILE, "paths")
     assert "font-family" not in svg, "font-family must be absent in paths output"
 
 
-@pytest.mark.skipif(FIXTURE_FILE is None, reason="no example fixtures found")
 def test_text_to_paths_is_valid_svg() -> None:
     """paths output must be well-formed XML."""
     import xml.etree.ElementTree as ET

--- a/tests/test_render_layout_invariants.py
+++ b/tests/test_render_layout_invariants.py
@@ -376,10 +376,42 @@ def _render_fixture(name: str, *, strict: bool = False) -> None:
     ],
 )
 def test_planned_fan_local_offset_frames_render_strictly(name: str) -> None:
+    """Each fan's drawn legs leave the fork on their own per-line lane.
+
+    A fan's local offset frame is only realised if the drawn polylines start on
+    the fork's per-line lane rather than on its bare marker row, and if the
+    legs stay distinct so the fan reads as an opening rather than one track.
+    """
     graph = parse_metro_mermaid((EXAMPLES / name).read_text())
     graph.strict = True
     compute_layout(graph)
-    render_svg(graph, THEMES["nfcore"])
+    plan = build_render_plan(graph, THEMES["nfcore"])
+
+    forks = {fan.fork_station_id for fan in graph.fan_plans}
+    assert forks, f"{name}: expected at least one recognised fan"
+
+    stations = plan.graph.values["stations"]
+    legs: dict[str, set[tuple[tuple[float, float], ...]]] = {}
+    for route, polyline in zip(plan.routes, plan.route_polylines, strict=True):
+        source = route.values["edge"].values["source"]
+        if source not in forks:
+            continue
+        line_id = route.values["line_id"]
+        station = stations.get(source)
+        offset = plan.station_offsets.get((source, line_id)) or 0.0
+        lane_y = station.values["y"] + offset
+        assert polyline[0] == pytest.approx((station.values["x"], lane_y)), (
+            f"{name}: {line_id} leg out of {source} is drawn from "
+            f"{polyline[0]}, off its lane at "
+            f"{(station.values['x'], lane_y)}"
+        )
+        legs.setdefault(source, set()).add(polyline)
+
+    for fork in sorted(forks):
+        assert len(legs.get(fork, set())) >= 2, (
+            f"{name}: fan at {fork} draws "
+            f"{len(legs.get(fork, set()))} distinct legs, so it does not open"
+        )
 
 
 # An inter-section route whose exit side faces away from its consumer must leave

--- a/tests/test_reserved_claim_consumption.py
+++ b/tests/test_reserved_claim_consumption.py
@@ -45,25 +45,33 @@ def _corpus() -> list[Path]:
 
 _CORPUS = _corpus()
 
-# Fixtures that never reach a route plan at all: fixtures under `invalid/`
-# and `nextflow/` are exercised by their own tests for the error they raise,
-# and the frozen determinism/topology fixtures abort on a routing invariant
-# tracked by other tests. None of them can be held to a claim-consumption
-# bound, so their failure to render is not itself a finding here.
+# Fixtures that never reach a route plan at all, so none of them can be held to
+# a claim-consumption bound. Their failure to render is not itself a finding
+# here, but only the first three groups are meant to stay that way: an entry
+# that is a defect rather than a category carries the issue tracking it, so the
+# allow-list cannot quietly absorb a new one.
 KNOWN_NOT_RENDERING = frozenset(
     {
+        # Frozen fuzz seeds: abort on a routing invariant that
+        # tests/test_convergence_planner.py holds them to instead.
         "tests/fixtures/hash_seed_determinism/seed_15.mmd",
         "tests/fixtures/hash_seed_determinism/seed_41.mmd",
         "tests/fixtures/hash_seed_determinism/seed_77.mmd",
+        # Deliberately invalid authoring, exercised by their own tests for the
+        # authoring error each one raises.
         "tests/fixtures/invalid/backward_feed_rl.mmd",
         "tests/fixtures/invalid/merge_trunk_rightward_source.mmd",
         "tests/fixtures/invalid/mixed_entry_opposing.mmd",
         "tests/fixtures/invalid/mixed_entry_perpendicular.mmd",
+        # Raw Nextflow DAG output, which needs convert_nextflow_dag before it
+        # is a metro source at all.
         "tests/fixtures/nextflow/duplicate_processes.mmd",
         "tests/fixtures/nextflow/flat_pipeline.mmd",
         "tests/fixtures/nextflow/unquoted_labels.mmd",
         "tests/fixtures/nextflow/variant_calling.mmd",
         "tests/fixtures/nextflow/with_subworkflows.mmd",
+        # A routing defect, not a category: the bottom-row climb dives below
+        # its own section box and the render aborts (#1889).
         "tests/fixtures/topologies/twoline_fanout_up.mmd",
     }
 )

--- a/tests/test_reserved_claim_consumption.py
+++ b/tests/test_reserved_claim_consumption.py
@@ -52,8 +52,9 @@ _CORPUS = _corpus()
 # allow-list cannot quietly absorb a new one.
 KNOWN_NOT_RENDERING = frozenset(
     {
-        # Frozen fuzz seeds: abort on a routing invariant that
-        # tests/test_convergence_planner.py holds them to instead.
+        # Frozen fuzz seeds: tests/test_hash_seed_determinism.py holds each one
+        # to its exact set of defect classes and to a hash of the exception it
+        # raises, so the abort is pinned there rather than unexamined.
         "tests/fixtures/hash_seed_determinism/seed_15.mmd",
         "tests/fixtures/hash_seed_determinism/seed_41.mmd",
         "tests/fixtures/hash_seed_determinism/seed_77.mmd",

--- a/tests/test_right_entry_corridor_descent_invariant.py
+++ b/tests/test_right_entry_corridor_descent_invariant.py
@@ -50,8 +50,6 @@ def _corridor_jog(mmd: str):
 @pytest.mark.parametrize("stem", _FIXTURES)
 def test_right_entry_corridor_descent_has_no_mid_run_jog(stem):
     path = TOPOLOGIES_DIR / f"{stem}.mmd"
-    if not path.exists():
-        pytest.skip(f"fixture {stem}.mmd not present")
     jog = _corridor_jog(path.read_text())
     assert jog is None, jog.message() if jog else ""
 

--- a/tests/test_routing_gate_coverage.py
+++ b/tests/test_routing_gate_coverage.py
@@ -30,23 +30,31 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 BASELINE_PATH = PROJECT_ROOT / "tests" / "data" / "routing_gate_coverage_baseline.json"
 SCRIPT_PATH = PROJECT_ROOT / "scripts" / "routing_gate_coverage.py"
 
+# The dedicated CI job sets this, so the interpreter skip below cannot let that
+# job report success on a run where the ratchet never executed.  A developer
+# sweeping the whole suite on another interpreter leaves it unset and skips.
+REQUIRE_ENV_VAR = "NF_METRO_REQUIRE_GATE_COVERAGE"
+
 
 @pytest.fixture(scope="module")
 def rgc():
     """The coverage script as an importable module, behind the version skip.
 
     The arc model is interpreter-specific, so the baseline only holds on the
-    pinned CPython; skip elsewhere.
+    pinned CPython; skip elsewhere unless :data:`REQUIRE_ENV_VAR` demands a run.
     """
     sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
     import routing_gate_coverage as module
 
     if sys.version_info[:2] != module.BASELINE_PYTHON:
-        pytest.skip(
+        reason = (
             f"gate baseline is pinned to CPython {module.BASELINE_PYTHON[0]}."
             f"{module.BASELINE_PYTHON[1]}; coverage's arc model differs on "
             f"{sys.version_info[0]}.{sys.version_info[1]}"
         )
+        if os.environ.get(REQUIRE_ENV_VAR) == "1":
+            pytest.fail(f"{REQUIRE_ENV_VAR}=1 but {reason}", pytrace=False)
+        pytest.skip(reason)
     return module
 
 

--- a/tests/test_svg_paths.py
+++ b/tests/test_svg_paths.py
@@ -3,7 +3,7 @@
 Validates that the SVG path rendering in svg.py correctly translates
 RoutedPath waypoints + curve_radii into well-formed SVG paths with:
 - Correct curve continuity (no gaps between adjacent curves)
-- Curve radii arrays matching the number of corners
+- One resolved curve radius per corner, formed at every direction change
 - Clamped radii that respect available segment budget
 - Concentric bundle lines maintaining distinct radii through curves
 """
@@ -11,6 +11,7 @@ RoutedPath waypoints + curve_radii into well-formed SVG paths with:
 import math
 import re
 import xml.etree.ElementTree as ET
+from collections import defaultdict
 from pathlib import Path
 
 import pytest
@@ -92,21 +93,65 @@ def _layout_and_route_file(path: Path) -> tuple:
 
 
 # ---------------------------------------------------------------------------
-# 1. Curve radii array length must match corner count
+# 1. One resolved radius per corner, and a formed curve at every turn
 # ---------------------------------------------------------------------------
 
 
+def _turning_corner_indices(points: list[tuple[float, float]]) -> list[int]:
+    """Corner indices at which the polyline changes direction.
+
+    Every interior waypoint is a corner by index, but a collinear one and one
+    flanked by a zero-length leg bend nothing, so neither is owed a curve.
+    """
+    turning = []
+    for i in range(1, len(points) - 1):
+        prev, corner, nxt = points[i - 1], points[i], points[i + 1]
+        incoming = (corner[0] - prev[0], corner[1] - prev[1])
+        outgoing = (nxt[0] - corner[0], nxt[1] - corner[1])
+        in_len = math.hypot(*incoming)
+        out_len = math.hypot(*outgoing)
+        if in_len == 0.0 or out_len == 0.0:
+            continue
+        cross = incoming[0] * outgoing[1] - incoming[1] * outgoing[0]
+        if abs(cross) / (in_len * out_len) > 1e-6:
+            turning.append(i - 1)
+    return turning
+
+
 class TestCurveRadiiLength:
-    """curve_radii (when present) must have exactly len(points) - 2 entries."""
+    """Every route carries one resolved radius per corner, and every corner
+    that changes direction resolves to a formed curve.
+
+    ``curve_radii`` is the per-corner request a handler may leave unset; the
+    resolved list is what the renderer draws, so both the explicit request and
+    the resolution are held to the corner count.  A direction change resolving
+    to a zero radius would draw as a mitre, not a curve.
+    """
 
     def _check_routes(self, routes: list[RoutedPath]):
+        assert routes, "expected the fixture to produce at least one route"
         for route in routes:
+            n_corners = max(len(route.points) - 2, 0)
+            where = (
+                f"Route {route.edge.source}->{route.edge.target} (line={route.line_id})"
+            )
             if route.curve_radii is not None:
-                n_corners = len(route.points) - 2
                 assert len(route.curve_radii) == n_corners, (
-                    f"Route {route.edge.source}->{route.edge.target} "
-                    f"(line={route.line_id}): {len(route.curve_radii)} radii "
+                    f"{where}: {len(route.curve_radii)} radii "
                     f"for {n_corners} corners ({len(route.points)} points)"
+                )
+            resolved = resolve_curve_radii(
+                route.points, route.curve_radii, default_radius=CURVE_RADIUS
+            )
+            assert len(resolved) == n_corners, (
+                f"{where}: {len(resolved)} resolved radii for {n_corners} "
+                f"corners ({len(route.points)} points)"
+            )
+            for corner_idx in _turning_corner_indices(route.points):
+                assert resolved[corner_idx] > 0.0, (
+                    f"{where}: direction change at point "
+                    f"{route.points[corner_idx + 1]} resolves to radius "
+                    f"{resolved[corner_idx]}, so it draws as a mitre"
                 )
 
     def test_simple_diamond(self):
@@ -309,11 +354,18 @@ class TestConcentricBundles:
     """Lines in the same bundle must have distinct curve_radii at shared corners."""
 
     def test_multi_line_bundle(self):
-        """Three lines sharing an L-shape must have 3 distinct radii."""
+        """Three lines sharing an L-shape must have 3 distinct radii.
+
+        The grid puts the target a row down as well as a column across, so the
+        bundle has to turn: sections side by side on one row route the bundle
+        straight and it carries no corner to be concentric about.
+        """
         mmd = (
             "%%metro line: l1 | Line1 | #ff0000\n"
             "%%metro line: l2 | Line2 | #00ff00\n"
             "%%metro line: l3 | Line3 | #0000ff\n"
+            "%%metro grid: s1 | 0,0\n"
+            "%%metro grid: s2 | 1,1\n"
             "graph LR\n"
             "    subgraph s1 [S1]\n"
             "        a[A]\n"
@@ -329,13 +381,11 @@ class TestConcentricBundles:
         offsets = compute_station_offsets(graph)
         routes = route_edges(graph, station_offsets=offsets)
 
-        # Find inter-section routes for the 3-line bundle
         inter = [r for r in routes if r.is_inter_section and r.curve_radii]
-        if not inter:
-            pytest.skip("No inter-section routes with curve_radii produced")
-
-        # Group by (source, target) to find co-routed bundles
-        from collections import defaultdict
+        assert len(inter) == 3, (
+            f"expected the 3-line bundle to turn out of s1, got {len(inter)} "
+            "inter-section routes carrying radii"
+        )
 
         bundles: dict[tuple[str, str], list[RoutedPath]] = defaultdict(list)
         for r in inter:
@@ -344,7 +394,6 @@ class TestConcentricBundles:
         for key, bundle in bundles.items():
             if len(bundle) < 2:
                 continue
-            # Each corner should have distinct radii across bundle lines
             for corner_idx in range(
                 min(len(r.curve_radii) for r in bundle if r.curve_radii)
             ):
@@ -357,41 +406,6 @@ class TestConcentricBundles:
                     assert len(set(radii)) == len(radii), (
                         f"Bundle {key} corner {corner_idx}: "
                         f"duplicate radii {radii} (lines would overlap)"
-                    )
-
-    def test_multi_line_bundle_fixture(self):
-        """The multi_line_bundle topology fixture should have distinct radii."""
-        fixture = TOPOLOGIES_DIR / "multi_line_bundle.mmd"
-        if not fixture.exists():
-            pytest.skip("multi_line_bundle.mmd not found")
-
-        graph = parse_metro_mermaid(fixture.read_text())
-        compute_layout(graph)
-        offsets = compute_station_offsets(graph)
-        routes = route_edges(graph, station_offsets=offsets)
-
-        inter = [r for r in routes if r.is_inter_section and r.curve_radii]
-        # Just verify no duplicate radii within any co-routed bundle
-        from collections import defaultdict
-
-        bundles: dict[tuple[str, str], list[RoutedPath]] = defaultdict(list)
-        for r in inter:
-            bundles[(r.edge.source, r.edge.target)].append(r)
-
-        for key, bundle in bundles.items():
-            if len(bundle) < 2:
-                continue
-            for corner_idx in range(
-                min(len(r.curve_radii) for r in bundle if r.curve_radii)
-            ):
-                radii = [
-                    r.curve_radii[corner_idx]
-                    for r in bundle
-                    if r.curve_radii and corner_idx < len(r.curve_radii)
-                ]
-                if len(radii) >= 2:
-                    assert len(set(radii)) == len(radii), (
-                        f"Bundle {key} corner {corner_idx}: duplicate radii {radii}"
                     )
 
 
@@ -534,8 +548,6 @@ class TestLineZOrderConsistent:
 
     def test_rnaseq_sections(self):
         fixture = EXAMPLES_DIR / "rnaseq_sections.mmd"
-        if not fixture.exists():
-            pytest.skip(f"fixture not available: {fixture}")
         _, _, _, svg = _layout_and_route_file(fixture)
         self._check(svg)
 
@@ -668,8 +680,6 @@ class TestConcentricArcCenters:
 
     def test_stacked_collector_corridor(self):
         fixture = EXAMPLES_DIR / "genomic_pipeline.mmd"
-        if not fixture.exists():
-            pytest.skip(f"fixture not available: {fixture}")
         _, routes, offsets, _ = _layout_and_route_file(fixture)
         self._check(routes, offsets)
 

--- a/tests/test_svg_paths.py
+++ b/tests/test_svg_paths.py
@@ -21,6 +21,10 @@ from nf_metro.layout.engine import compute_layout
 from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.layout.routing.common import RoutedPath
 from nf_metro.layout.routing.corners import curve_tangents, resolve_curve_radii
+from nf_metro.layout.routing.invariants import (
+    _ORTHOGONAL_TURN_FLOOR,
+    _ORTHOGONAL_TURN_TOL,
+)
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render import build_render_plan, emit_render_plan
 from nf_metro.render.animate import _points_to_svg_path
@@ -118,14 +122,28 @@ def _turning_corner_indices(points: list[tuple[float, float]]) -> list[int]:
     return turning
 
 
-class TestCurveRadiiLength:
-    """Every route carries one resolved radius per corner, and every corner
-    that changes direction resolves to a formed curve.
+def _requested_corner_radius(route: RoutedPath, corner_idx: int) -> float:
+    """The radius the route's handler asked for at *corner_idx*.
 
-    ``curve_radii`` is the per-corner request a handler may leave unset; the
-    resolved list is what the renderer draws, so both the explicit request and
-    the resolution are held to the corner count.  A direction change resolving
-    to a zero radius would draw as a mitre, not a curve.
+    Mirrors :func:`check_orthogonal_turns_form_curves`: an unset entry means the
+    handler expressed no preference and takes the default.
+    """
+    desired = route.curve_radii
+    if desired and corner_idx < len(desired) and desired[corner_idx] is not None:
+        return desired[corner_idx]
+    return CURVE_RADIUS
+
+
+class TestCurveRadiiLength:
+    """Every routed edge carries one radius per corner, and reaches the engine's
+    own formed-curve floor at each corner that changes direction.
+
+    ``curve_radii`` is the per-corner request a handler may leave unset, so both
+    it and the budget-clamped resolution of it are held to the corner count.
+    The floor is :func:`check_orthogonal_turns_form_curves`'s, imported so the
+    two cannot drift: below it a turn draws as a hard corner.  That guard polices
+    orthogonal inter-section turns only, and the bound is applied here to every
+    route and to diagonal turns as well.
     """
 
     def _check_routes(self, routes: list[RoutedPath]):
@@ -148,10 +166,15 @@ class TestCurveRadiiLength:
                 f"corners ({len(route.points)} points)"
             )
             for corner_idx in _turning_corner_indices(route.points):
-                assert resolved[corner_idx] > 0.0, (
+                requested = _requested_corner_radius(route, corner_idx)
+                # A corner asking for a tighter arc than the floor curves as
+                # designed, which is the exemption the guard itself makes.
+                floor = min(_ORTHOGONAL_TURN_FLOOR, requested) - _ORTHOGONAL_TURN_TOL
+                assert resolved[corner_idx] >= floor, (
                     f"{where}: direction change at point "
                     f"{route.points[corner_idx + 1]} resolves to radius "
-                    f"{resolved[corner_idx]}, so it draws as a mitre"
+                    f"{resolved[corner_idx]:.3f}, below the {floor:.3f} floor "
+                    f"for a requested {requested:.3f}, so it draws as a hard corner"
                 )
 
     def test_simple_diamond(self):

--- a/tests/test_triage_tool.py
+++ b/tests/test_triage_tool.py
@@ -22,8 +22,7 @@ _INVARIANTS_SRC = _REPO_ROOT / "tests" / "test_layout_invariants.py"
 
 
 def _load_build_review():
-    if not _BUILD_REVIEW.is_file():
-        pytest.skip(f"triage tool not present at {_BUILD_REVIEW}")
+    assert _BUILD_REVIEW.is_file(), f"triage tool missing at {_BUILD_REVIEW}"
     spec = importlib.util.spec_from_file_location("triage_build_review", _BUILD_REVIEW)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
Closes gaps where a test's name promised more than its body could fail on. Every claim below was measured on this branch, and each strengthened assertion was checked to red under a temporary source mutation.

## Assertions that could not fail

**`tests/test_svg_paths.py` `TestCurveRadiiLength`.** The whole body sat behind `if route.curve_radii is not None`, which holds for 792 of the 6541 routes across the 284 topology fixtures (12.1%), leaving 66 of the parametrized cases asserting nothing. Every route is now held to one *resolved* radius per corner (via `resolve_curve_radii`, the engine's own source of truth) and, at every direction change, to the formed-curve floor of `check_orthogonal_turns_form_curves`: `_ORTHOGONAL_TURN_FLOOR - _ORTHOGONAL_TURN_TOL`, i.e. 2.5px, imported from that guard so the two cannot drift, and carrying the guard's exemption for a corner that deliberately asks for a tighter arc. That guard polices orthogonal inter-section turns only; the bound is applied here to every route and to diagonal turns as well, which the corpus supports (minimum effective radius at a turn: 6.0 orthogonal, 2.83 diagonal). Collinear interior waypoints (50 in the corpus) and vertices flanked by a zero-length leg (28) are corners by index but bend nothing, so they are excluded. All 284 cases now assert; 269 reach the formed-curve claim and the 15 straight-only fixtures are held to the corner count and to producing routes at all.

**`tests/test_svg_paths.py` `TestConcentricBundles`.** `test_multi_line_bundle` routed its three-line bundle between two sections on one grid row, which never turns, so it always took its own `no inter-section routes with curve_radii` skip. Its mmd now places the target a row down as well as a column across and the test asserts the bundle turns. `test_multi_line_bundle_fixture` looped over an empty list for the same reason (`examples/topologies/multi_line_bundle.mmd` is three sections on one row, zero corners in 60 routes) and passed green while asserting nothing; it is dropped, because `test_concentric_bundle_corners.py::test_no_non_concentric_bundle_corners_in_gallery` already sweeps every shipped fixture, that one included, for the same property using the production invariant.

**`tests/test_constant_relations.py::test_relations_hold_on_current_values`.** `constants.py` calls `_check_constant_relations()` at module import, so the module's own `import ... as c` had already run it: a broken relation errored at collection and the body could only observe the success that had already happened. Deleted. The import-time call is the real guard, `test_violation_raises` already covers the falsifiable direction, and five tests pin the individual orderings. The module docstring now says that importing `constants` is itself the check.

**`tests/test_reserved_claim_consumption.py`'s frozen fuzz seeds** are held by `tests/test_hash_seed_determinism.py`, which pins each seed to its exact set of defect classes and to a sha256 of the exception contract it raises.

**`tests/test_render_layout_invariants.py::test_planned_fan_local_offset_frames_render_strictly`.** It rendered three fixtures under `graph.strict = True` and asserted nothing. It now measures the drawn geometry from the render plan: every leg out of a fan's fork station starts exactly on that fork's per-line lane (`station.y` plus its `station_offsets` entry) rather than on the bare marker row, and each fan draws at least two distinct legs so the fan opens. Strictness is unchanged: `build_render_plan` goes through the same settle path that raises.

## The routing-gates job could pass green having run nothing

`tests/test_routing_gate_coverage.py` skips its whole module when the interpreter is not `BASELINE_PYTHON`, and the module is `--ignore`d in the test matrix, so its dedicated job is the ratchet's only run and nothing asserted that the run happened. A divergence between the job's `3.11` pin and the baseline would have stopped a two-sided ratchet behind a green tick.

Two guards, both directions:

- `NF_METRO_REQUIRE_GATE_COVERAGE=1`, set by the `routing-gates` job step alone, turns the interpreter skip into a `pytest.fail`. Every test in the module depends on the `rgc` fixture, so a mismatch errors all 28. A developer sweeping the suite on 3.12 leaves it unset and still gets a skip.
- `test_ci_workflows.py::test_routing_gate_job_pins_the_baseline_interpreter_and_demands_a_run` reads `BASELINE_PYTHON` from the script and asserts the job pins that exact version, that the matrix still ignores the module, and that the env var and the module path are both on **the single step that invokes pytest**. Asserted against the whole job block instead, those two would also hold for a job that sets the variable on a neighbouring step, where it has no effect, or that runs a different test file: a guard against a no-op job that a no-op job could satisfy. A `_steps()` helper splits the job at its step markers so each claim lands on the step it is about.

## Missing fixtures no longer disarm their locks

Five sites skipped when their fixture was absent, so deleting a fixture turned a regression lock into a green skip. The fixtures and the triage script are tracked repo files, so a missing one is now a hard failure: `tests/test_bridge_glyph.py`, `tests/test_svg_paths.py` (three sites), `tests/test_right_entry_corridor_descent_invariant.py`, `tests/test_triage_tool.py`, `tests/test_font_portability.py`.

`test_issue484_same_colour_crossover_is_bridged` was the one already disarmed. `issue484.mmd` was renamed to `examples/longread_variant_calling.mmd` (only the title changed), so the test never ran at all. It runs against that path, and asserts what its `(~1616, 263)` coordinate stood for, without a coordinate that any global compaction of the map moves (it now sits at `(1534, 266)`):

- A crossing is a *unique* intersection interior to both segments. Two parallel runs sharing a channel are excluded however far they overlap, since there is no point at which one passes over the other. This map contains 14 such collinear bam overlaps, so accepting them is a live loophole rather than a theoretical one.
- The map holds **exactly one** genuine bam crossing, and it must be the one between the legs into `tr_calling` and `structural_variants` (named by section, not coordinate; the crossing drop serves more than one downstream leg, so the documented pair is required to be among them rather than to be the whole set).
- Exactly one bam gap fires, and its centre is on that crossing.

Uniqueness of the crossing is what supplies the specificity the coordinate used to: there is no second crossing site for a stray bridge to satisfy, so no coarse position check is needed. The result is strictly stronger than the coordinate, which checked neither that the gap sat at a crossing at all nor how many gaps fired.

`test_font_portability` chose its fixture as `EXAMPLES[0]` out of an unsorted `glob`, making the subject of eight tests filesystem-dependent; the glob is sorted.

`tests/test_bare_render.py` and `tests/test_topology_validation.py` carry the same class of guard and are deliberately untouched here: they belong to the examples-portability change.

## One genuinely broken fixture in an allow-list

`KNOWN_NOT_RENDERING` in `tests/test_reserved_claim_consumption.py` held 13 fixtures with no distinction between them. Twelve are categories that cannot render by design, each confirmed: four `tests/fixtures/invalid/` fixtures raise `BackwardFlowError` / `MixedEntryDirectionError`, five `nextflow/` fixtures raise `ValueError` for needing `convert_nextflow_dag`, and three `hash_seed_determinism` seeds abort on a routing invariant that `tests/test_convergence_planner.py` holds them to instead.

`tests/fixtures/topologies/twoline_fanout_up.mmd` is not a category. It aborts the render outright, `nf-metro render` included, on `check_bottom_row_climb_stays_at_row_level`: its `to_new` leg drops 72px below its own section box, runs the full traverse down there and only then climbs, while its sibling `to_src` shows the row-level corridor was clear. That is filed as #1889 with an inline repro, and the allow-list entry now names it, so the list cannot quietly absorb another undeclared defect.

## Verification

- `ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy` (119 files), and the prek prettier hook on `ci.yml`: all clean.
- Every touched module in full, plus `tests/test_hash_seed_determinism.py`: 3248 passed, 41 skipped. The remaining skips are content-conditional and visible (a fixture with no multi-corner route, a compact-mode exemption), not silent green passes.
- `tests/test_routing_gate_coverage.py` on 3.11 with the env var set: 28 passed.
