### PR TITLE
refactor(routing): state the plan-ownership rule once for passes and guards

### DIFF
--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -3235,9 +3235,8 @@ def planner_owns_segment_or_boundary(route: RoutedPath, rank: int) -> bool:
 
     Translating a segment stretches its two flanking legs to meet it, so both
     of its corners re-form: a segment beside a route-system-owned boundary is
-    as unavailable to a pass as an owned segment is.  Every normalisation pass
-    that moves a channel and every guard that refuses the result reads this
-    wider rule, so they read it from here.
+    as unavailable to a pass as an owned segment is.  The normalisation passes
+    and closing guards that read this wider rule read it from here.
     """
     return planner_owns_segment(route, rank) or route_system_owns_segment_boundary(
         route, rank

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -3215,6 +3215,10 @@ def planner_owns_segment(route: RoutedPath, rank: int) -> bool:
     refuse the result both have to agree on which coordinates are theirs: a pass
     reading a wider rule than its guard would move geometry the guard then
     refuses, and a narrower one would leave a defect neither reports.
+
+    This names one rank exactly.  A pass that translates a whole segment wants
+    :func:`planner_owns_segment_or_boundary` instead, which is the reading the
+    normalisation passes and the closing guards share.
     """
     return (
         convergence_owns_segment_boundary(route, rank)
@@ -3223,6 +3227,20 @@ def planner_owns_segment(route: RoutedPath, rank: int) -> bool:
         or (
             route.exit_turn_axis_id is not None and route.exit_turn_segment_rank == rank
         )
+    )
+
+
+def planner_owns_segment_or_boundary(route: RoutedPath, rank: int) -> bool:
+    """Whether a plan fixes this segment or a corner at either end of it.
+
+    Translating a segment stretches its two flanking legs to meet it, so both
+    of its corners re-form: a segment beside a route-system-owned boundary is
+    as unavailable to a pass as an owned segment is.  Every normalisation pass
+    that moves a channel and every guard that refuses the result reads this
+    wider rule, so they read it from here.
+    """
+    return planner_owns_segment(route, rank) or route_system_owns_segment_boundary(
+        route, rank
     )
 
 

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -86,10 +86,9 @@ from nf_metro.layout.routing.common import (
     opposing_entry_confluence_slots,
     peeloff_target_slots,
     perp_entry_consumer,
-    planner_owns_segment,
+    planner_owns_segment_or_boundary,
     port_peeloff_tail,
     resolve_section,
-    route_system_owns_segment_boundary,
     same_destination_approach_slots,
     segments_properly_cross,
     tail_on_slot,
@@ -466,10 +465,7 @@ class MergeConfluenceBandCross:
 
 def _descent_is_plan_owned(route: RoutedPath) -> bool:
     """Whether a plan owns the final descent riser (``points[-3]``) of a tail."""
-    riser_rank = len(route.points) - 3
-    return planner_owns_segment(
-        route, riser_rank
-    ) or route_system_owns_segment_boundary(route, riser_rank)
+    return planner_owns_segment_or_boundary(route, len(route.points) - 3)
 
 
 def _terminal_entry_port_id(graph: MetroGraph, route: RoutedPath) -> str | None:

--- a/src/nf_metro/layout/routing/member_geometry.py
+++ b/src/nf_metro/layout/routing/member_geometry.py
@@ -957,9 +957,9 @@ def _upstream_plan_fixes_channel(
 ) -> bool:
     """Whether a plan this allocator did not make already fixes the channel x.
 
-    Deliberately not :func:`planner_owns_segment_or_boundary`, which every
-    normalisation pass reads.  Three arms differ, and each difference is a
-    property of running before the member plan is stamped:
+    Deliberately not :func:`planner_owns_segment_or_boundary`.  Three arms
+    differ, and each difference is a property of running before the member plan
+    is stamped:
 
     * A fan or exit-lane transition membership resolved the whole corridor
       rather than one segment of it, so it fixes the channel at whichever rank

--- a/src/nf_metro/layout/routing/member_geometry.py
+++ b/src/nf_metro/layout/routing/member_geometry.py
@@ -950,11 +950,29 @@ def _index_materialized_channels(
     )
 
 
-def _planner_owns_channel(
+def _upstream_plan_fixes_channel(
     route: RoutedPath,
     segment_rank: int,
     movable_exit_plan_ids: frozenset[ExitTurnPlanId] = frozenset(),
 ) -> bool:
+    """Whether a plan this allocator did not make already fixes the channel x.
+
+    Deliberately not :func:`planner_owns_segment_or_boundary`, which every
+    normalisation pass reads.  Three arms differ, and each difference is a
+    property of running before the member plan is stamped:
+
+    * A fan or exit-lane transition membership resolved the whole corridor
+      rather than one segment of it, so it fixes the channel at whichever rank
+      the query names.
+    * The segments either side of a planned exit turn are fixed too, because
+      the turn's runway is measured along them -- the widening
+      :func:`convergence_owns_segment_boundary` already applies to a
+      convergence boundary.  A turn whose plan the caller listed as movable is
+      excluded: re-seating it is the caller's own right.
+    * ``route_system_owned_segment_ranks`` is this allocator's own output, and
+      every route reaching it is a handler template rather than a stamped
+      member route, so that field is empty here by construction.
+    """
     if route.exit_lane_transition_plan_id is not None:
         return True
     if route.fan_plan_id is not None or route.fan_route_emitter is not None:
@@ -1119,7 +1137,7 @@ def _align_packed_cell_handoffs(
             carrier_channels,
             key=lambda item: abs(item.channel.x - descent_x),
         )
-        assert not _planner_owns_channel(
+        assert not _upstream_plan_fixes_channel(
             route, handoff_channel.channel.idx, movable_exit_plan_ids
         ), "packed-cell handoff descent has a conflicting plan owner"
         bounds = _channel_bounds(handoff_channel, ctx)
@@ -1142,7 +1160,7 @@ def _align_same_line_channels(
     for item in materialized:
         route = item.candidate.route
         channel = item.channel
-        if item.key in seated or _planner_owns_channel(
+        if item.key in seated or _upstream_plan_fixes_channel(
             route, channel.idx, movable_exit_plan_ids
         ):
             continue
@@ -1390,7 +1408,7 @@ def _channel_bundles(
     ] = defaultdict(list)
     seen: set[tuple[RouteSystemId, ResolvedEdge, int]] = set()
     for item in materialized:
-        if item.key in seen or _planner_owns_channel(
+        if item.key in seen or _upstream_plan_fixes_channel(
             item.candidate.route, item.channel.idx, movable_exit_plan_ids
         ):
             continue
@@ -1469,7 +1487,7 @@ def _allocate_member_gap_channels(
         *(
             _claim_for_materialized_channel(item)
             for item in materialized
-            if _planner_owns_channel(
+            if _upstream_plan_fixes_channel(
                 item.candidate.route, item.channel.idx, movable_exit_plan_ids
             )
         ),

--- a/src/nf_metro/layout/routing/normalize.py
+++ b/src/nf_metro/layout/routing/normalize.py
@@ -69,6 +69,7 @@ from nf_metro.layout.routing.common import (
     packed_cell_neighbor_edges,
     peeloff_target_slots,
     planner_owns_segment,
+    planner_owns_segment_or_boundary,
     port_peeloff_tail,
     route_system_owns_segment_boundary,
     same_destination_approach_slots,
@@ -640,9 +641,7 @@ def _locate_slot_channel_with_slot(
 
 def _planner_owns_channel(channel: _VChannel) -> bool:
     """Whether a pre-routing plan owns this channel's final geometry."""
-    return planner_owns_segment(
-        channel.route, channel.idx
-    ) or route_system_owns_segment_boundary(channel.route, channel.idx)
+    return planner_owns_segment_or_boundary(channel.route, channel.idx)
 
 
 def _fused_sibling_spans(
@@ -1034,10 +1033,7 @@ def _rederive_semantic_end_corners(
                 kind == "source" and route.exit_lane_transition_plan_id is not None
             ) or (kind == "target" and route.exit_turn_segment_rank == rank):
                 continue
-            if respect_owned_corners and (
-                planner_owns_segment(route, rank)
-                or route_system_owns_segment_boundary(route, rank)
-            ):
+            if respect_owned_corners and planner_owns_segment_or_boundary(route, rank):
                 continue
             cohorts[kind, owner, incoming, outgoing].append(
                 _SemanticEndCorner(
@@ -1992,10 +1988,7 @@ def _unify_coincident_corner_radii(
     )
 
     def corner_is_owned(route: RoutedPath, radius_index: int) -> bool:
-        corner_rank = radius_index + 1
-        return planner_owns_segment(
-            route, corner_rank
-        ) or route_system_owns_segment_boundary(route, corner_rank)
+        return planner_owns_segment_or_boundary(route, radius_index + 1)
 
     for rp in routes:
         radii = rp.curve_radii


### PR DESCRIPTION
Behaviour-preserving deduplication of the plan-ownership predicate in the routing layer. Closes #1899.

## What this changes

The question "does a pre-routing plan fix this segment's coordinate" was answered by six separate expressions across four modules, including two functions both named `_planner_owns_channel` that gave opposite answers on the same input.

- `common.py` gains `planner_owns_segment_or_boundary`, which states the reading the normalisation passes and the closing guards share: a plan owns the segment, or owns a corner at either end of it. `planner_owns_segment` keeps its narrower exact-rank meaning and now points at the wider sibling.
- The four verbatim copies of that expression derive from it instead: `normalize._planner_owns_channel`, `normalize._rederive_semantic_end_corners`, `normalize._unify_coincident_corner_radii.corner_is_owned`, and `invariants._descent_is_plan_owned`.
- `member_geometry._planner_owns_channel` becomes `_upstream_plan_fixes_channel`. Its body is unchanged. It answers a different question, and its docstring now states each of the three ways it differs from the shared predicate and why each holds at plan-build time.

Two similar-looking expressions are deliberately left alone, because neither is the same rule: `common.py:1613 tail_segment_is_held` carries an exit-turn replan carve-out inside the conjunction, and `normalize.py:4231` is `A or (B and C)` by operator precedence rather than a plain disjunction. Folding either into the shared helper would change behaviour.

## Verification

Renders are byte-identical across the shipped corpus (`examples/`, `examples/topologies/`, `examples/guide/`, `tests/fixtures/`).

- 1,576 renders (394 `.mmd` files under four option settings: default, `center_ports: true`, `diamond_style: symmetric`, and both). **0 md5 differences** among the 1,501 that render. Error sets compared separately: **75 before, 75 after, symmetric difference empty**, and no error changed type.
- The same corpus with layout validation forced on (394 files, since `compute_layout` defaults it off): **0 md5 differences**, and the 19 pre-existing validation failures are identical before and after by key and by message text.
- `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 407 files already formatted; `mypy src/nf_metro` reports no issues across 119 files.
- `tests/test_topology_validation.py`, `tests/test_layout_invariants.py`, `tests/test_routing_gate_coverage.py`, `tests/test_guard_registry_golden.py`: 26,606 passed, 68 skipped, 7 xfailed.

## Merge sequencing

Checked against the two PRs that touch the same files. No overlapping hunks either way, so this can merge in any order relative to them.

- **#1893** touches `invariants.py` at lines 901 and 2807. This PR touches `invariants.py` at lines 89 to 92 (imports) and 468.
- **#1905** touches `common.py` at line 2353 and `invariants.py` at lines 126 and 181. This PR touches `common.py` at lines 3218 and 3233. Line-number offsets from #1905's deletions apply cleanly; no context windows intersect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
