### PR TITLE
refactor(layout): read tolerances from the constants that name them

### DIFF
--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1821,7 +1821,7 @@ def _guard_section_top_padding(
     """
     from nf_metro.layout.phases.planned_fans import planned_fan_layout_section_ids
 
-    tol = 1.0
+    tol = COORD_TOLERANCE
     planned_sections = planned_fan_layout_section_ids(graph)
     for section in graph.sections.values():
         if section.bbox_h <= 0:
@@ -1867,7 +1867,7 @@ def _guard_section_bottom_padding(
     bottom above that target means a later pass crowded the lowest marker
     against the box edge.
     """
-    tol = 1.0
+    tol = COORD_TOLERANCE
     for section in graph.sections.values():
         if section.bbox_h <= 0:
             continue
@@ -1900,7 +1900,7 @@ def _guard_rail_above_label_band(graph: MetroGraph, phase: str) -> None:
     # Function-local: a module-level import would close a layout import cycle.
     from nf_metro.layout.rail_mode import _rail_label_band, rail_above_label_ids
 
-    tol = 1.0
+    tol = COORD_TOLERANCE
     for section in graph.sections.values():
         if section.bbox_h <= 0 or not graph.is_rail_section(section.id):
             continue
@@ -1929,7 +1929,7 @@ def _guard_rail_stations_seat_on_rails(graph: MetroGraph, phase: str) -> None:
     """
     if not graph.has_rail_sections:
         return
-    tol = 1.0
+    tol = COORD_TOLERANCE
     for section in graph.sections.values():
         if not graph.is_rail_section(section.id):
             continue
@@ -1961,7 +1961,7 @@ def _guard_terminus_icons_within_bbox(graph: MetroGraph, phase: str) -> None:
     above the station marker; the section bbox must reserve that extent so
     the icon doesn't spill past the box edge (issue #254).
     """
-    tol = 1.0
+    tol = COORD_TOLERANCE
     for section in graph.sections.values():
         if section.bbox_h <= 0 or lanes_run_along_y(section.direction):
             continue
@@ -2007,7 +2007,7 @@ def _guard_single_trunk_off_track_step(graph: MetroGraph, phase: str) -> None:
         return
     anchor_of = _off_track_anchor_of(graph)
     junction_ids = graph.junction_ids
-    tol = 1.0
+    tol = COORD_TOLERANCE
     for off_id, anchor_id in anchor_of.items():
         off_st = graph.stations.get(off_id)
         anchor = graph.stations.get(anchor_id)
@@ -2053,7 +2053,7 @@ def _guard_off_track_input_column_stack(graph: MetroGraph, phase: str) -> None:
     junction_ids = graph.junction_ids
     y_spacing = compute_min_y_spacing(graph)
     anchor_of = _off_track_anchor_of(graph)
-    tol = 1.0
+    tol = COORD_TOLERANCE
 
     def _flow_coord(st: Station) -> float:
         flow, _cross = section_axes(graph.sections.get(st.section_id or ""))
@@ -2122,7 +2122,7 @@ def _guard_sparse_loop_station_clears_column_neighbour(
         return
     floor = _LOOP_STATION_COLUMN_CLEARANCE_FRACTION * pitch
     half_grid = graph.half_grid_station_ids
-    tol = 1.0
+    tol = COORD_TOLERANCE
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
             continue
@@ -2183,7 +2183,7 @@ def _guard_off_track_consumer_on_trunk(graph: MetroGraph, phase: str) -> None:
     for a TB/BT one.
     """
     junction_ids = graph.junction_ids
-    tol = 1.0
+    tol = COORD_TOLERANCE
     consumers = {
         anchor_id
         for off_id, anchor_id in _off_track_anchor_of(graph).items()
@@ -2232,7 +2232,7 @@ def _guard_symfan_entry_port_on_feeder_trunk(graph: MetroGraph, phase: str) -> N
 
     if graph.diamond_style != "symmetric":
         return
-    tol = 1.0
+    tol = COORD_TOLERANCE
     for section in graph.sections.values():
         feeder = _symfan_entry_port_feeder_y(graph, section)
         if feeder is None:

--- a/src/nf_metro/layout/routing/corners.py
+++ b/src/nf_metro/layout/routing/corners.py
@@ -26,7 +26,12 @@ import math
 from collections.abc import Iterable
 from typing import NamedTuple
 
-from nf_metro.layout.constants import COORD_TOLERANCE, CURVE_RADIUS, OFFSET_STEP
+from nf_metro.layout.constants import (
+    COORD_TOLERANCE,
+    COORD_TOLERANCE_FINE,
+    CURVE_RADIUS,
+    OFFSET_STEP,
+)
 from nf_metro.layout.routing.common import Direction, bundle_width
 
 # ---------------------------------------------------------------------------
@@ -152,6 +157,43 @@ def resolve_curve_radii(
         )
         for corner_idx in range(n_corners)
     ]
+
+
+def desired_curve_radii(
+    points: list[tuple[float, float]],
+    default_radius: float = CURVE_RADIUS,
+) -> list[float]:
+    """The radius each interior vertex of *points* asks for.
+
+    A vertex whose flanking legs continue in the same direction is not a
+    direction change and asks for no curve; every other interior vertex asks
+    for *default_radius*.  Feed the result to :func:`resolve_curve_radii` to
+    clamp it to the segment budgets.
+
+    Straightness is measured as the outgoing leg's perpendicular distance
+    from the incoming leg's line, so the :data:`COORD_TOLERANCE_FINE` band
+    means the same deviation on a short leg as on a long one.
+    """
+    desired: list[float] = []
+    for index in range(1, len(points) - 1):
+        incoming = (
+            points[index][0] - points[index - 1][0],
+            points[index][1] - points[index - 1][1],
+        )
+        outgoing = (
+            points[index + 1][0] - points[index][0],
+            points[index + 1][1] - points[index][1],
+        )
+        cross = incoming[0] * outgoing[1] - incoming[1] * outgoing[0]
+        dot = incoming[0] * outgoing[0] + incoming[1] * outgoing[1]
+        incoming_length = math.hypot(incoming[0], incoming[1])
+        straight_through = (
+            dot > 0.0
+            and incoming_length > 0.0
+            and abs(cross) / incoming_length <= COORD_TOLERANCE_FINE
+        )
+        desired.append(0.0 if straight_through else default_radius)
+    return desired
 
 
 class CornerTangent(NamedTuple):

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -39,6 +39,7 @@ from nf_metro.layout.constants import (
     FLOW_ALIGNED_PORT_ADVICE,
     MIN_CORRIDOR_Y_OVERLAP,
     OFFSET_STEP,
+    SAME_COORD_TOLERANCE,
     SAME_Y_TOLERANCE,
     graph_offset_step,
 )
@@ -964,7 +965,7 @@ def check_seam_segments_meet_at_port(
 # at the corner apex (the line stops short of its own bend); anything
 # larger than this is the seam / notch the fix closes.  A PERPENDICULAR
 # gap up to a stroke width is hidden under the line and tolerated.
-_TAIL_JOIN_TANGENT_TOLERANCE = 1.0
+_TAIL_JOIN_TANGENT_TOLERANCE = COORD_TOLERANCE
 
 
 @dataclass(frozen=True)
@@ -1154,7 +1155,7 @@ def check_fanout_lane_continuity(
 # deliberately asked for a tighter arc.  Below this, a horizontal-to-vertical
 # turn reads as a hard corner rather than a formed curve.
 _ORTHOGONAL_TURN_FLOOR = 3.0
-_ORTHOGONAL_TURN_TOL = 0.5
+_ORTHOGONAL_TURN_TOL = SAME_COORD_TOLERANCE
 
 
 @dataclass(frozen=True)
@@ -2066,7 +2067,7 @@ class DiagonalOverlapViolation:
         )
 
 
-_COLLINEAR_LATERAL_TOL = 1.0
+_COLLINEAR_LATERAL_TOL = COORD_TOLERANCE
 _COLLINEAR_MIN_SPAN = 40.0
 
 # A diagonal bundle's lines must keep a true perpendicular separation, not a
@@ -4090,11 +4091,11 @@ def check_stacked_elbow_clearance(
 # ---------------------------------------------------------------------------
 
 # Arc-centre spread above this reads as a visible pinch/gap through the bend.
-_CONCENTRIC_CENTRE_TOLERANCE = 1.0
+_CONCENTRIC_CENTRE_TOLERANCE = COORD_TOLERANCE
 # A corner counts as wholesale-translated only when both flanking legs are
 # offset from the bundle-mate by the same amount; a difference above this means
 # one leg is pinned (a transition corner), where non-concentric is intended.
-_WHOLESALE_LEG_TOLERANCE = 1.0
+_WHOLESALE_LEG_TOLERANCE = COORD_TOLERANCE
 
 
 @dataclass(frozen=True)
@@ -5170,7 +5171,7 @@ def check_no_hanging_routes(
 # px: doubles as the floor below which an endpoint offset is negligible and the
 # slack within which a terminal segment counts as horizontal (so its Y-shift is
 # a lateral separation rather than an along-travel displacement).
-_LATERAL_OFFSET_TOL = 1.0
+_LATERAL_OFFSET_TOL = COORD_TOLERANCE
 
 
 @dataclass(frozen=True)

--- a/src/nf_metro/render/path_geometry.py
+++ b/src/nf_metro/render/path_geometry.py
@@ -12,6 +12,7 @@ from nf_metro.layout.routing.common import (
     SourceTurnout,
     segment_direction,
 )
+from nf_metro.layout.routing.corners import desired_curve_radii
 
 Point = tuple[float, float]
 
@@ -152,19 +153,7 @@ def materialize_source_turnout(
             "source turnout directions disagree with drawable geometry"
         )
 
-    desired = []
-    for index in range(1, len(materialized) - 1):
-        incoming = (
-            materialized[index][0] - materialized[index - 1][0],
-            materialized[index][1] - materialized[index - 1][1],
-        )
-        outgoing = (
-            materialized[index + 1][0] - materialized[index][0],
-            materialized[index + 1][1] - materialized[index][1],
-        )
-        cross = incoming[0] * outgoing[1] - incoming[1] * outgoing[0]
-        dot = incoming[0] * outgoing[0] + incoming[1] * outgoing[1]
-        desired.append(0.0 if abs(cross) <= 1e-9 and dot > 0.0 else default_radius)
+    desired = desired_curve_radii(materialized, default_radius=default_radius)
     if curve_radii is not None:
         start = segment_shift
         if start + len(curve_radii) > len(desired):

--- a/tests/test_tolerance_constant_ratchet.py
+++ b/tests/test_tolerance_constant_ratchet.py
@@ -1,0 +1,186 @@
+"""Ratchet on tolerance values spelled out where a named constant already holds them.
+
+``layout/constants.py`` is the vocabulary of geometry tolerances: every band the
+engine measures against ("same coordinate", "same assigned row", the guard
+slack) is named and documented there. A pass or guard that writes one of those
+numbers out at its own call site instead reads the same band by coincidence, so
+tuning the named constant leaves the copy behind and a guard can drift away from
+the pass it guards.
+
+A tolerance whose value differs from every named one is a genuinely independent
+band, and is not counted: the class this bounds is duplication, not the
+existence of a local tolerance.
+
+``constants.py`` itself is exempt, since that is where the named values are
+defined rather than used.
+
+The bound is exact, not slack: ``test_tolerance_literal_baseline_is_current``
+asserts equality, so clearing a site has to lower the number here in the same
+change. Never raise it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import NamedTuple
+
+_LAYOUT_DIR = Path(__file__).resolve().parents[1] / "src" / "nf_metro" / "layout"
+
+_VOCABULARY_FILE = "constants.py"
+
+_BASELINE = 0
+
+
+class ToleranceLiteral(NamedTuple):
+    """One tolerance-named binding whose literal duplicates a named constant."""
+
+    name: str
+    value: float
+    line: int
+    constants: tuple[str, ...]
+
+
+def _is_tolerance_name(name: str) -> bool:
+    return "tol" in name.lower()
+
+
+def _literal_number(node: ast.expr | None) -> float | None:
+    """The value of *node* when it is a bare numeric literal, else None.
+
+    A composed expression (``OFFSET_STEP + 1.0``) states how its value relates
+    to the vocabulary, so only a whole-value literal counts.
+    """
+    if not isinstance(node, ast.Constant) or isinstance(node.value, bool):
+        return None
+    return float(node.value) if isinstance(node.value, (int, float)) else None
+
+
+def _assigned_names(node: ast.Assign | ast.AnnAssign) -> list[str]:
+    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+    return [t.id for t in targets if isinstance(t, ast.Name)]
+
+
+def tolerance_vocabulary(source: str) -> dict[float, tuple[str, ...]]:
+    """Map each module-level tolerance constant's value to the names holding it."""
+    vocabulary: dict[float, list[str]] = {}
+    for node in ast.parse(source).body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        value = _literal_number(node.value)
+        if value is None:
+            continue
+        for name in _assigned_names(node):
+            if _is_tolerance_name(name):
+                vocabulary.setdefault(value, []).append(name)
+    return {value: tuple(names) for value, names in vocabulary.items()}
+
+
+def duplicated_tolerance_literals(
+    source: str,
+    vocabulary: dict[float, tuple[str, ...]],
+) -> dict[str, ToleranceLiteral]:
+    """Tolerance-named bindings in *source* whose literal a constant already holds.
+
+    Keys are ``<enclosing qualname>::<name>`` for a binding inside a function or
+    class and the bare name at module level, so a site keeps one key as the file
+    around it changes.
+    """
+    found: dict[str, ToleranceLiteral] = {}
+
+    def visit(node: ast.AST, scope: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.Assign, ast.AnnAssign)):
+                value = _literal_number(child.value)
+                constants = vocabulary.get(value) if value is not None else None
+                if value is not None and constants:
+                    for name in _assigned_names(child):
+                        if _is_tolerance_name(name):
+                            key = f"{scope}::{name}" if scope else name
+                            found[key] = ToleranceLiteral(
+                                name, value, child.lineno, constants
+                            )
+            inner = scope
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                inner = f"{scope}.{child.name}" if scope else child.name
+            visit(child, inner)
+
+    visit(ast.parse(source), "")
+    return found
+
+
+def _layout_sites() -> dict[str, ToleranceLiteral]:
+    vocabulary = tolerance_vocabulary((_LAYOUT_DIR / _VOCABULARY_FILE).read_text())
+    sites: dict[str, ToleranceLiteral] = {}
+    for path in sorted(_LAYOUT_DIR.rglob("*.py")):
+        relative = path.relative_to(_LAYOUT_DIR)
+        if str(relative) == _VOCABULARY_FILE:
+            continue
+        for key, site in duplicated_tolerance_literals(
+            path.read_text(), vocabulary
+        ).items():
+            sites[f"{relative}::{key}"] = site
+    return sites
+
+
+def _breakdown(sites: dict[str, ToleranceLiteral]) -> str:
+    return "\n  ".join(
+        f"{key}:{site.line} = {site.value} (see {', '.join(site.constants)})"
+        for key, site in sorted(sites.items())
+    )
+
+
+def test_no_tolerance_literals_duplicating_named_constants() -> None:
+    sites = _layout_sites()
+    assert len(sites) <= _BASELINE, (
+        f"tolerance literals duplicating a named constant rose to {len(sites)} "
+        f"(baseline {_BASELINE}). Import the constant, or give the site a value "
+        "and a docstring of its own so it is visibly an independent band.\n  "
+        f"{_breakdown(sites)}"
+    )
+
+
+def test_tolerance_literal_baseline_is_current() -> None:
+    sites = _layout_sites()
+    assert len(sites) == _BASELINE, (
+        f"tolerance-literal baseline is {_BASELINE}, live count is {len(sites)}; "
+        "lower the baseline in the same change that clears a site"
+    )
+
+
+def test_vocabulary_collects_tolerance_constants_by_value() -> None:
+    source = """
+COORD_TOLERANCE: float = 1.0
+EDGE_CONNECT_TOL = 1.0
+CURVE_RADIUS = 10.0
+GUARD_TOLERANCE = 5.0
+DERIVED_TOLERANCE = GUARD_TOLERANCE
+"""
+
+    assert tolerance_vocabulary(source) == {
+        1.0: ("COORD_TOLERANCE", "EDGE_CONNECT_TOL"),
+        5.0: ("GUARD_TOLERANCE",),
+    }
+
+
+def test_function_local_duplicate_is_found_with_its_scope() -> None:
+    source = """
+def _guard_padding(graph):
+    tol = 1.0
+    return tol
+"""
+
+    assert duplicated_tolerance_literals(source, {1.0: ("COORD_TOLERANCE",)}) == {
+        "_guard_padding::tol": ToleranceLiteral("tol", 1.0, 3, ("COORD_TOLERANCE",))
+    }
+
+
+def test_independent_value_and_named_reference_are_not_counted() -> None:
+    source = """
+_SLOPE_TOL = 0.12
+_LATERAL_TOL = COORD_TOLERANCE
+_COINCIDE_TOL = OFFSET_STEP + 1.0
+_MIN_SPAN = 1.0
+"""
+
+    assert duplicated_tolerance_literals(source, {1.0: ("COORD_TOLERANCE",)}) == {}

--- a/tests/test_tolerance_constant_ratchet.py
+++ b/tests/test_tolerance_constant_ratchet.py
@@ -22,6 +22,8 @@ change. Never raise it.
 from __future__ import annotations
 
 import ast
+import operator
+from collections.abc import Callable
 from pathlib import Path
 from typing import NamedTuple
 
@@ -45,15 +47,51 @@ def _is_tolerance_name(name: str) -> bool:
     return "tol" in name.lower()
 
 
-def _literal_number(node: ast.expr | None) -> float | None:
-    """The value of *node* when it is a bare numeric literal, else None.
+_BINARY_OPS: dict[type[ast.operator], Callable[[float, float], float]] = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
 
-    A composed expression (``OFFSET_STEP + 1.0``) states how its value relates
-    to the vocabulary, so only a whole-value literal counts.
+_UNARY_OPS: dict[type[ast.unaryop], Callable[[float], float]] = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+}
+
+
+def _folded_number(node: ast.expr | None) -> float | None:
+    """The value of *node* when it folds to a number over constants alone.
+
+    A margin derived from the vocabulary (``OFFSET_STEP + 1.0``) states how its
+    value relates to it, so any expression referencing a name yields None.
+    Arithmetic over constants alone is the value itself however it is spelled,
+    so it folds rather than escaping.
     """
-    if not isinstance(node, ast.Constant) or isinstance(node.value, bool):
-        return None
-    return float(node.value) if isinstance(node.value, (int, float)) else None
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
+            return None
+        return float(node.value)
+    if isinstance(node, ast.UnaryOp):
+        unary = _UNARY_OPS.get(type(node.op))
+        operand = _folded_number(node.operand)
+        if unary is None or operand is None:
+            return None
+        return float(unary(operand))
+    if isinstance(node, ast.BinOp):
+        binary = _BINARY_OPS.get(type(node.op))
+        left = _folded_number(node.left)
+        right = _folded_number(node.right)
+        if binary is None or left is None or right is None:
+            return None
+        try:
+            return float(binary(left, right))
+        except (ArithmeticError, ValueError):
+            return None
+    return None
 
 
 def _assigned_names(node: ast.Assign | ast.AnnAssign) -> list[str]:
@@ -67,7 +105,7 @@ def tolerance_vocabulary(source: str) -> dict[float, tuple[str, ...]]:
     for node in ast.parse(source).body:
         if not isinstance(node, (ast.Assign, ast.AnnAssign)):
             continue
-        value = _literal_number(node.value)
+        value = _folded_number(node.value)
         if value is None:
             continue
         for name in _assigned_names(node):
@@ -91,7 +129,7 @@ def duplicated_tolerance_literals(
     def visit(node: ast.AST, scope: str) -> None:
         for child in ast.iter_child_nodes(node):
             if isinstance(child, (ast.Assign, ast.AnnAssign)):
-                value = _literal_number(child.value)
+                value = _folded_number(child.value)
                 constants = vocabulary.get(value) if value is not None else None
                 if value is not None and constants:
                     for name in _assigned_names(child):
@@ -175,11 +213,30 @@ def _guard_padding(graph):
     }
 
 
+def test_constant_only_arithmetic_folds_to_the_duplicated_value() -> None:
+    source = """
+_SUM_TOL = 1.0 + 0.0
+_PRODUCT_TOL = 1.0 * 1
+_NEGATED_TOL = -(-1.0)
+_PARENTHESISED_TOL = (1.00)
+"""
+
+    assert duplicated_tolerance_literals(source, {1.0: ("COORD_TOLERANCE",)}) == {
+        "_SUM_TOL": ToleranceLiteral("_SUM_TOL", 1.0, 2, ("COORD_TOLERANCE",)),
+        "_PRODUCT_TOL": ToleranceLiteral("_PRODUCT_TOL", 1.0, 3, ("COORD_TOLERANCE",)),
+        "_NEGATED_TOL": ToleranceLiteral("_NEGATED_TOL", 1.0, 4, ("COORD_TOLERANCE",)),
+        "_PARENTHESISED_TOL": ToleranceLiteral(
+            "_PARENTHESISED_TOL", 1.0, 5, ("COORD_TOLERANCE",)
+        ),
+    }
+
+
 def test_independent_value_and_named_reference_are_not_counted() -> None:
     source = """
 _SLOPE_TOL = 0.12
 _LATERAL_TOL = COORD_TOLERANCE
 _COINCIDE_TOL = OFFSET_STEP + 1.0
+_SCALED_TOL = 0.25 * (OFFSET_STEP + 0.0)
 _MIN_SPAN = 1.0
 """
 


### PR DESCRIPTION
Closes #1900. Closes #1903.

Both issues are the same defect class: a geometry tolerance decided where it is
used rather than read from the constant that names it, so a pass and the guard
that checks it can be tuned apart without either side noticing.

## Corner collinearity moves into the radius machinery (#1900)

`render/path_geometry.py::materialize_source_turnout` rebuilt the desired-radius
list from cross and dot products with its own epsilon (`1e-9`). That rule now
lives in `layout/routing/corners.py` as `desired_curve_radii(points,
default_radius=CURVE_RADIUS)`, beside `resolve_curve_radii`, which is documented
as the single source of truth for radius resolution. `path_geometry` calls it and
keeps only what is specific to a turnout: overlaying the route's declared radii
at the synthetic-prefix offset and pinning the plan-owned turnout radius.

Straightness is now measured as the outgoing leg's perpendicular distance from
the incoming leg's line, compared against `COORD_TOLERANCE_FINE`. The normalised
form makes the band a distance, which is what that constant means, so it admits
the same deviation on a short leg as on a long one.

## Tolerance literals read their constants (#1903)

- Ten `tol = 1.0` locals in `layout/phases/guards.py` now read `COORD_TOLERANCE`
  (same value), matching the file's other eight `tol =` sites.
- Six private aliases in `layout/routing/invariants.py` now point at the shared
  constant. Each measures whether two coordinates coincide, so none of them has
  a value independent of the vocabulary:

  | alias | now |
  | --- | --- |
  | `_TAIL_JOIN_TANGENT_TOLERANCE` | `COORD_TOLERANCE` |
  | `_COLLINEAR_LATERAL_TOL` | `COORD_TOLERANCE` |
  | `_CONCENTRIC_CENTRE_TOLERANCE` | `COORD_TOLERANCE` |
  | `_WHOLESALE_LEG_TOLERANCE` | `COORD_TOLERANCE` |
  | `_LATERAL_OFFSET_TOL` | `COORD_TOLERANCE` |
  | `_ORTHOGONAL_TURN_TOL` | `SAME_COORD_TOLERANCE` |

  The names and their comments stay: they say what each check measures, which
  the bare constant does not.

`_WHOLESALE_LEG_TOLERANCE` is passed to `corners.wholesale_corner_translation`,
whose own `tolerance` default is `COORD_TOLERANCE`, so the two ends of that call
now agree by construction.

## Ratchet

`tests/test_tolerance_constant_ratchet.py` bounds the class at **zero**: no
binding whose name contains `tol`, anywhere under `src/nf_metro/layout/`, may
hold a bare numeric literal that a tolerance constant in `layout/constants.py`
already defines. `constants.py` is exempt as the file where the vocabulary is
defined. A tolerance whose value matches nothing named is a genuinely
independent band and is not counted. An expression escapes only by referencing
a name, which is what makes a margin derived (`OFFSET_STEP + 1.0`) rather than
duplicated; arithmetic over constants alone is folded first, so `1.0 + 0.0` and
`1.0 * 1` are caught as the duplicates they are. Run against `origin/main` the detector finds exactly the sixteen sites
the issues name.

## Behaviour

Renders are byte-identical. Every shipped `.mmd` (335 files under `examples/`)
rendered through `render_string` before and after, joined on path:

| sweep | files | md5 differences | errors before | errors after |
| --- | --- | --- | --- | --- |
| default | 335 | 0 | 0 | 0 |
| `compute_layout(validate=True)` | 335 | 0 | 2 | 2 |

The two validate-on errors are the same two files with identical messages on
both sides (`examples/riboseq_metro.mmd`, `examples/sarek_metro.mmd`, both the
pre-existing title-band floor guard), so no guard changed its verdict either.

`ruff check`, `ruff format --check` and `mypy` are clean.

## Merge sequencing

Two sibling PRs also touch `guards.py` and `invariants.py`: one correcting
comments and docstrings (including `invariants.py:2811` and `guards.py:5577`),
one removing dead code (including the `Side` enum at `invariants.py:129`). The
hunks here are confined to the tolerance bindings and their import lines, so
they should not collide, but they are in the same files.
