### PR TITLE
docs(changelog): record the directive-validation behaviour changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ history.
   map that relied on the exemption needs one `%%metro line:` directive per id
   its edges name, and the error names the missing ids with the source line of
   each.
+- **Breaking: a duplicate `%%metro line:` id now keeps the first declaration
+  rather than the last, and warns.** A map declaring the same id twice silently
+  took the later spelling, so redeclaring a line late in the file was a working
+  way to change its colour, style or `inactive` state. The redeclaration is now
+  reported and dropped. A map that relied on the old precedence needs its
+  intended values on the first declaration of each id.
+- Unknown values and unresolvable references in `%%metro` directives are
+  reported instead of ignored. `style:` validates against the theme names;
+  `off_track:`, `group:`, `marker:`, `grid:`, `line_spread:`, `file:`, `files:`,
+  `dir:`, `entry:`, `exit:` and `interchange:` warn on a station, section or
+  line id the map never defines; and a `line:` declaration missing its id, name
+  or colour is rejected whole rather than registering a partial line.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the two missing `[Unreleased]` entries for behaviour changes that shipped in #1891.

- **Duplicate `%%metro line:` id now keeps the first declaration**, where the map previously took the last silently. This one matters most: redeclaring a line late in the file was a working way to change its colour, style or `inactive` state, so a map relying on that precedence changes appearance rather than failing.
- **Unknown directive values and unresolvable references are now reported** rather than ignored, across `style:`, `off_track:`, `group:`, `marker:`, `grid:`, `line_spread:`, `file:`, `files:`, `dir:`, `entry:`, `exit:` and `interchange:`, and a `line:` declaration missing a field is rejected whole.

## Why these were missing

#1891's author was asked to leave the release-note story to #1909, so that the render-side rejection of undeclared lines got one account rather than two overlapping ones. #1909 duly recorded that change. The duplicate-id precedence inversion and the new directive warnings are separate behaviour changes, and fell through the gap.

The `.mmd` directive surface is declared public API under semver in this file, so both entries are marked breaking.

## Test plan

- [x] `prettier` passes via the pre-commit hook
- [x] No code change, so no render or test impact