### PR TITLE
fix(render): resolve declared-inactive lines in render_svg

### DIFF
--- a/src/nf_metro/api.py
+++ b/src/nf_metro/api.py
@@ -132,16 +132,10 @@ def render_graph_result(
     graph: MetroGraph, theme_obj: Theme, cfg: RenderConfig
 ) -> RenderResult:
     """Render a laid-out graph and return its content and plan."""
-    if cfg.inactive_line_ids is not None:
-        bad = cfg.inactive_line_ids - graph.lines.keys()
-        if bad:
-            raise UnknownInactiveLineError(
-                f"--inactive-lines: unknown line ID(s) {sorted(bad)}; "
-                f"known lines are {sorted(graph.lines)}"
-            )
-        effective_inactive = cfg.inactive_line_ids
-    else:
-        effective_inactive = graph.default_inactive_line_ids()
+    try:
+        effective_inactive = graph.resolve_inactive_line_ids(cfg.inactive_line_ids)
+    except UnknownInactiveLineError as e:
+        raise UnknownInactiveLineError(f"--inactive-lines: {e}") from None
     if cfg.output_format == "html":
         plan = build_render_plan(
             graph,

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, NamedTuple, TypedDict
 
-from nf_metro.errors import NfMetroError
+from nf_metro.errors import NfMetroError, UnknownInactiveLineError
 from nf_metro.parser.provenance import LayoutProvenance
 
 if TYPE_CHECKING:
@@ -769,6 +769,26 @@ class MetroGraph:
         return frozenset(
             line_id for line_id, line in self.lines.items() if line.default_inactive
         )
+
+    def resolve_inactive_line_ids(
+        self, override: frozenset[str] | None
+    ) -> frozenset[str]:
+        """Inactive-line set for a render: *override* if given, else the default.
+
+        ``None`` falls back to :meth:`default_inactive_line_ids`. A supplied set
+        replaces that default outright and is validated against the known lines,
+        raising :class:`~nf_metro.errors.UnknownInactiveLineError` on any ID the
+        map does not declare.
+        """
+        if override is None:
+            return self.default_inactive_line_ids()
+        bad = override - self.lines.keys()
+        if bad:
+            raise UnknownInactiveLineError(
+                f"unknown line ID(s) {sorted(bad)}; "
+                f"known lines are {sorted(self.lines)}"
+            )
+        return override
 
     def add_station(self, station: Station) -> None:
         self.stations[station.id] = station

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -676,11 +676,7 @@ def render_svg(
     if animate is None:
         animate = graph.animate
 
-    effective_inactive = (
-        inactive_line_ids
-        if inactive_line_ids is not None
-        else graph.default_inactive_line_ids()
-    )
+    effective_inactive = graph.resolve_inactive_line_ids(inactive_line_ids)
 
     metrics_face = metrics_face_for_portability(font_portability)
     with class_prefix_context(svg_class_prefix):

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -604,6 +604,7 @@ def render_svg(
     self_color_scheme: bool = True,
     baked_mode: str | None = None,
     bare: bool = False,
+    inactive_line_ids: frozenset[str] | None = None,
 ) -> str:
     """Render a metro map graph to an SVG string.
 
@@ -662,12 +663,24 @@ def render_svg(
     hugs the diagram content.  The attribution watermark is kept.  Use for
     embedding the SVG inside a host page that supplies its own frame and
     heading.
+
+    ``inactive_line_ids``: the set of line IDs to render muted grey.  ``None``
+    (default) resolves the map's own declared-inactive set
+    (``graph.default_inactive_line_ids()``), so a ``%%metro line: ... inactive``
+    directive takes effect.  An explicit set overrides that declaration for this
+    render; an empty set forces every line active.
     """
     if not graph.stations:
         return '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
 
     if animate is None:
         animate = graph.animate
+
+    effective_inactive = (
+        inactive_line_ids
+        if inactive_line_ids is not None
+        else graph.default_inactive_line_ids()
+    )
 
     metrics_face = metrics_face_for_portability(font_portability)
     with class_prefix_context(svg_class_prefix):
@@ -682,6 +695,7 @@ def render_svg(
             chrome_css=chrome_css,
             bare=bare,
             metrics_face=metrics_face,
+            inactive_line_ids=effective_inactive,
         )
         svg = emit_render_plan(
             plan,

--- a/tests/test_inactive_lines.py
+++ b/tests/test_inactive_lines.py
@@ -450,6 +450,14 @@ def test_render_svg_empty_override_forces_all_active():
     assert theme.muted_line_color not in rects["z"]
 
 
+def test_render_svg_unknown_inactive_line_raises():
+    graph = prepare_graph(DECLARED_INACTIVE_MAP)
+    theme = resolve_theme(None, graph)
+    with pytest.raises(UnknownInactiveLineError) as exc:
+        render_svg(graph, theme, inactive_line_ids=frozenset({"nope"}))
+    assert "nope" in str(exc.value)
+
+
 def test_muted_theme_overrides_every_field_on_a_plain_theme():
     # A render always passes the plan's FrozenRecord theme; a dataclass Theme
     # takes the dataclasses.replace path instead.

--- a/tests/test_inactive_lines.py
+++ b/tests/test_inactive_lines.py
@@ -6,6 +6,7 @@ import xml.etree.ElementTree as ET
 import pytest
 
 from nf_metro import RenderConfig, UnknownInactiveLineError, render_string
+from nf_metro.api import prepare_graph
 from nf_metro.errors import NfMetroError
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render.constants import (
@@ -14,8 +15,8 @@ from nf_metro.render.constants import (
     station_is_muted,
 )
 from nf_metro.render.plan import FrozenRecord
-from nf_metro.render.svg import _muted_line_theme
-from nf_metro.themes import NFCORE_DARK_THEME
+from nf_metro.render.svg import _muted_line_theme, render_svg
+from nf_metro.themes import NFCORE_DARK_THEME, resolve_theme
 
 MUTED = NFCORE_DARK_THEME.muted_line_color
 
@@ -401,6 +402,52 @@ def test_chrome_css_and_presentation_attribute_agree_on_muting(brand):
     assert ("fill", "Mid") in covered
     assert ("fill", "Sizes") in covered
     assert {prop for prop, _ in covered} == {"fill", "stroke"}
+
+
+# ---------------------------------------------------------------------------
+# render_svg direct entry point (playground / live server path)
+# ---------------------------------------------------------------------------
+
+# render_svg is the entry point the browser playground and the live-progress
+# server call directly, bypassing RenderConfig/render_graph_result. It must
+# resolve the map's declared-inactive set itself, or those surfaces silently
+# render every line active.
+
+
+def _render_svg(src, **kwargs):
+    graph = prepare_graph(src)
+    theme = resolve_theme(None, graph)
+    return graph, theme, render_svg(graph, theme, **kwargs)
+
+
+def test_render_svg_mutes_declared_inactive_by_default():
+    graph, theme, svg = _render_svg(DECLARED_INACTIVE_MAP)
+    muted = theme.muted_line_color
+    assert 'stroke="#ff0000"' not in svg
+    assert f'stroke="{muted}"' in svg
+    assert _rects_by_station(svg)["x"] == {muted}
+
+
+def test_render_svg_explicit_override_replaces_declared_set():
+    graph = prepare_graph(DECLARED_INACTIVE_MAP)
+    theme = resolve_theme(None, graph)
+    svg = render_svg(graph, theme, inactive_line_ids=frozenset({"b"}))
+    assert 'stroke="#ff0000"' in svg  # line a active
+    assert 'stroke="#0000ff"' not in svg  # line b muted
+    rects = _rects_by_station(svg)
+    assert theme.muted_line_color not in rects["x"]
+    assert rects["z"] == {theme.muted_line_color}
+
+
+def test_render_svg_empty_override_forces_all_active():
+    graph = prepare_graph(DECLARED_INACTIVE_MAP)
+    theme = resolve_theme(None, graph)
+    svg = render_svg(graph, theme, inactive_line_ids=frozenset())
+    assert 'stroke="#ff0000"' in svg
+    assert 'stroke="#0000ff"' in svg
+    rects = _rects_by_station(svg)
+    assert theme.muted_line_color not in rects["x"]
+    assert theme.muted_line_color not in rects["z"]
 
 
 def test_muted_theme_overrides_every_field_on_a_plain_theme():

--- a/tests/test_live_server.py
+++ b/tests/test_live_server.py
@@ -59,6 +59,24 @@ def test_only_mapped_stations_are_overlaid():
     assert ids == {"trim", "qc"}  # 'input' has no process: directive
 
 
+def test_declared_inactive_line_is_muted_in_served_svg():
+    src = (
+        "%%metro line: a | A | #ff0000 | solid\n"
+        "%%metro line: b | B | #0000ff | solid | inactive\n"
+        "graph LR\n"
+        "    input[In] -->|a| trim[Trim]\n"
+        "    trim -->|b| qc[QC]\n"
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        graph = parse_metro_mermaid(src)
+    compute_layout(graph)
+    theme = THEMES["nfcore"]
+    model = MapModel(graph, theme)
+    assert 'stroke="#0000ff"' not in model.svg_body
+    assert f'stroke="{theme.muted_line_color}"' in model.svg_body
+
+
 def test_state_machine_queued_running_done():
     state = ProgressState(_model())
     state.ingest({"event": "started", "runName": "r"})

--- a/tests/test_live_server.py
+++ b/tests/test_live_server.py
@@ -34,16 +34,16 @@ MMD = (
 )
 
 
-def _graph():
+def _graph(src: str = MMD):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        graph = parse_metro_mermaid(MMD)
+        graph = parse_metro_mermaid(src)
     compute_layout(graph)
     return graph
 
 
-def _model() -> MapModel:
-    return MapModel(_graph(), THEMES["nfcore"])
+def _model(src: str = MMD) -> MapModel:
+    return MapModel(_graph(src), THEMES["nfcore"])
 
 
 def _ev(event, task_id, process, status=""):
@@ -60,21 +60,16 @@ def test_only_mapped_stations_are_overlaid():
 
 
 def test_declared_inactive_line_is_muted_in_served_svg():
-    src = (
+    model = _model(
         "%%metro line: a | A | #ff0000 | solid\n"
         "%%metro line: b | B | #0000ff | solid | inactive\n"
         "graph LR\n"
         "    input[In] -->|a| trim[Trim]\n"
         "    trim -->|b| qc[QC]\n"
     )
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        graph = parse_metro_mermaid(src)
-    compute_layout(graph)
-    theme = THEMES["nfcore"]
-    model = MapModel(graph, theme)
+    muted = THEMES["nfcore"].muted_line_color
     assert 'stroke="#0000ff"' not in model.svg_body
-    assert f'stroke="{theme.muted_line_color}"' in model.svg_body
+    assert f'stroke="{muted}"' in model.svg_body
 
 
 def test_state_machine_queued_running_done():


### PR DESCRIPTION
## Summary
- `render_svg()` gains an `inactive_line_ids: frozenset[str] | None = None` parameter and now resolves the graph's declared-inactive line set (`%%metro line: ... inactive`) when none is given, instead of always rendering every line active.
- Adds `MetroGraph.resolve_inactive_line_ids()`, a shared resolve+validate helper used by both `render_svg` and `api.render_graph_result`, so an unknown/typo'd line ID raises `UnknownInactiveLineError` consistently from either entry point.
- Fixes the browser playground and the live-progress server (`live/server.py`), both of which call `render_svg` directly and previously never muted inactive lines regardless of what the source `.mmd` declared.

Fixes #1912

## Test plan
- [x] Targeted tests pass locally (including new invariant tests); CI matrix runs the full suite
- [x] ruff check + ruff format clean on whole repo
- [x] Runtime validation added (`UnknownInactiveLineError` raised consistently from both entry points)
- [ ] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1923/)
- [ ] Render-preview verdict: pending