### PR TITLE
docs(routing): point the channel-pin cross-reference at the function that reads it

### DIFF
--- a/src/nf_metro/layout/routing/member_geometry.py
+++ b/src/nf_metro/layout/routing/member_geometry.py
@@ -1540,7 +1540,7 @@ def _seat_claimed_segments_before_freeze(
     planned axis (and, where the corridor is shared with a bundle bound
     elsewhere, onto that bundle's lane).  A pinned member is left where its plan
     placed it.  The pin is read from the segment rank -- as
-    :func:`_planner_owns_channel` reads it -- not the plan id: the settled
+    :func:`_upstream_plan_fixes_channel` reads it -- not the plan id: the settled
     two-pass path clears a member's segment rank (restoring it after this pass)
     to hand it to seating, and reads as unpinned here.
     """


### PR DESCRIPTION
## Summary

`member_geometry.py:1543` referred to `:func:`_planner_owns_channel``, which does not exist in that module. The function that reads the pin from the segment rank there is `_upstream_plan_fixes_channel`, defined at `:953`. One word; the sentence's meaning was already correct.

## How it got there

A semantic merge conflict rather than a bad diff, and worth recording because no check catches this class.

- #1906 renamed `member_geometry`'s `_planner_owns_channel` to `_upstream_plan_fixes_channel`, so that the two same-named predicates in `normalize.py` and `member_geometry.py` stopped claiming to be one rule. `normalize.py` deliberately keeps the old name.
- `05702991b` ("read the exit-turn seat pin from the segment rank") added this cross-reference on a branch that does not descend from that rename, written against code where the name still resolved.

Neither merge parent contained both, so each change was individually clean and only the combination dangles. Nothing validates `:func:` targets, so CI had no way to notice.

Verified this is the only instance: of the 21 occurrences of the old name across `src`, `tests` and `docs`, the other 20 all resolve. `normalize.py` holds the definition and 14 call sites plus its own `:func:` reference at `:3111`; `tests/test_route_system_emission.py:421` qualifies it as `normalize._planner_owns_channel`; and the prose in `docs/dev/routing_gate_coverage.md:839` and `tests/data/routing_gate_triage.json:1015` describes a `normalize.py` gate.

## Test plan

- [x] Docstring text only, no executable change
- [x] `git grep` over `src`, `tests` and `docs` confirms no remaining reference to a `_planner_owns_channel` that does not resolve