### PR TITLE
fix(security): escape directive-authored text at SVG/HTML injection points

### DIFF
--- a/src/nf_metro/parser/directives.py
+++ b/src/nf_metro/parser/directives.py
@@ -126,6 +126,14 @@ def _dir_process(value: str, graph: MetroGraph) -> None:
 _COLOR_FUNCTION = re.compile(r"[A-Za-z-]+\(.*\)\Z")
 _COLOR_KEYWORDS = frozenset({"currentcolor", "transparent", "none"})
 
+_LINE_ID_PATTERN = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
+"""Same identifier charset as the ``NAME`` grammar token for node/section ids.
+
+A declared line id lands in SVG ``class=``/``data-*`` attributes verbatim, so
+constraining it here (rather than escaping at every emission site) rules out
+attribute-injection through this vector entirely.
+"""
+
 
 def _is_color(value: str) -> bool:
     """True when *value* is a colour an SVG stroke can resolve.
@@ -160,6 +168,12 @@ def _dir_line(value: str, graph: MetroGraph) -> None:
             f"'id | name | #color' [| style [| {LINE_INACTIVE_KEYWORD}]]",
         )
         return
+    if not _LINE_ID_PATTERN.fullmatch(line_id):
+        raise ValueError(
+            f"%%metro line: id {line_id!r} is invalid; line ids must match "
+            "[a-zA-Z_][a-zA-Z0-9_]* (the same charset as node and section "
+            "ids) since they land in SVG class/data-* attributes verbatim"
+        )
     if line_id in graph.lines:
         _warn_directive(
             "line",

--- a/src/nf_metro/parser/directives.py
+++ b/src/nf_metro/parser/directives.py
@@ -20,7 +20,12 @@ from nf_metro.options import (
     coerce,
     is_line_order,
 )
-from nf_metro.parser.grammar import _normalize_multiline_text, _split_csv, _unquote
+from nf_metro.parser.grammar import (
+    _IDENTIFIER_CHARSET,
+    _normalize_multiline_text,
+    _split_csv,
+    _unquote,
+)
 from nf_metro.parser.model import (
     FLOW_DIRECTIONS,
     LINE_INACTIVE_KEYWORD,
@@ -126,8 +131,9 @@ def _dir_process(value: str, graph: MetroGraph) -> None:
 _COLOR_FUNCTION = re.compile(r"[A-Za-z-]+\(.*\)\Z")
 _COLOR_KEYWORDS = frozenset({"currentcolor", "transparent", "none"})
 
-_LINE_ID_PATTERN = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
-"""Same identifier charset as the ``NAME`` grammar token for node/section ids.
+_LINE_ID_PATTERN = re.compile(_IDENTIFIER_CHARSET)
+"""Built from the same charset as the ``NAME`` grammar token for node/section
+ids (:data:`nf_metro.parser.grammar._IDENTIFIER_CHARSET`).
 
 A declared line id lands in SVG ``class=``/``data-*`` attributes verbatim, so
 constraining it here (rather than escaping at every emission site) rules out
@@ -169,11 +175,14 @@ def _dir_line(value: str, graph: MetroGraph) -> None:
         )
         return
     if not _LINE_ID_PATTERN.fullmatch(line_id):
-        raise ValueError(
-            f"%%metro line: id {line_id!r} is invalid; line ids must match "
-            "[a-zA-Z_][a-zA-Z0-9_]* (the same charset as node and section "
-            "ids) since they land in SVG class/data-* attributes verbatim"
+        _warn_directive(
+            "line",
+            f"id {line_id!r} is invalid; ignoring the declaration. Line ids "
+            "must match [a-zA-Z_][a-zA-Z0-9_]* (the same charset as node and "
+            "section ids), since they land in SVG class/data-* attributes "
+            "verbatim",
         )
+        return
     if line_id in graph.lines:
         _warn_directive(
             "line",

--- a/src/nf_metro/parser/grammar.py
+++ b/src/nf_metro/parser/grammar.py
@@ -22,12 +22,19 @@ from nf_metro.parser.model import UNANNOTATED_LINE_ID
 # shaped endpoints.
 _SHAPE_INNER = r"(?:(?!-->|---|==>).)+"
 
+# Charset for node, section, and line ids. Exposed as a module-level constant
+# (rather than left inline in the NAME terminal below) so callers outside the
+# grammar - e.g. line-id validation in directives.py - can match it without
+# invoking the parser.
+_IDENTIFIER_CHARSET = r"[a-zA-Z_][a-zA-Z0-9_]*"
+
 # Grammar for the Mermaid subset nf-metro accepts. The document is a sequence
 # of newline-separated statements; inline whitespace (indentation, spacing
 # around arrows) is ignored, but whitespace inside the whole-line terminals
 # (labels, directive bodies) is part of the match. Whole-line terminals carry
 # an explicit priority so they win the tie against NAME on their keyword.
-# ``_I_`` in the SHAPE terminal is substituted with ``_SHAPE_INNER`` below.
+# ``_I_`` in the SHAPE terminal is substituted with ``_SHAPE_INNER``, and
+# ``_ID_`` in the NAME terminal with ``_IDENTIFIER_CHARSET``, below.
 _GRAMMAR = r"""
 start: (_statement? _NL)* _statement?
 
@@ -57,7 +64,7 @@ COMMENT.3: /%%[^\n]*/
 ARROW.4: /-->|---|==>/
 EDGELABEL.4: /\|[^|\n]*\|/
 SHAPE.4: /\(\[_I_\]\)|\[\[_I_\]\]|\(\(_I_\)\)|\[_I_\]|\(_I_\)|\{_I_\}/
-NAME: /[a-zA-Z_][a-zA-Z0-9_]*/
+NAME: /_ID_/
 JUNK.-10: /[^\n]+/
 
 _NL: /\r?\n/
@@ -261,7 +268,11 @@ class _StatementTransformer(Transformer[Token, list[_Statement]]):
 # low-priority junk rule and be dropped. A lalr/contextual parser commits
 # token-by-token and cannot backtrack such a line to junk, so it would turn a
 # dropped line (e.g. an inline-shaped edge endpoint) into a fatal error.
-_PARSER = Lark(_GRAMMAR.replace("_I_", _SHAPE_INNER), parser="earley", lexer="dynamic")
+_PARSER = Lark(
+    _GRAMMAR.replace("_I_", _SHAPE_INNER).replace("_ID_", _IDENTIFIER_CHARSET),
+    parser="earley",
+    lexer="dynamic",
+)
 _TRANSFORMER = _StatementTransformer()
 
 

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -6,6 +6,7 @@ Theme-dependent values remain in style.py.
 
 from __future__ import annotations
 
+import html
 from typing import TYPE_CHECKING
 
 from nf_metro.layout.constants import (
@@ -275,12 +276,16 @@ def effective_line_color(
     when given, is the colour for an *active* line, taking priority over the
     line's own (the chevron site passes ``theme.directional_marker_color`` so a
     themed marker colour wins); an inactive line mutes regardless.
+
+    The line's own colour is directive-authored text that lands verbatim in
+    an SVG attribute, so it is HTML-escaped here (a no-op on every legitimate
+    CSS colour form).
     """
     if line is not None and line.id in inactive_line_ids:
         return theme.muted_line_color
     if active_color:
         return active_color
-    return line.color if line is not None else FALLBACK_LINE_COLOR
+    return html.escape(line.color) if line is not None else FALLBACK_LINE_COLOR
 
 
 def station_is_muted(

--- a/src/nf_metro/render/driver.js
+++ b/src/nf_metro/render/driver.js
@@ -1,3 +1,13 @@
+// Escapes untrusted text (directive-authored line colours/labels, and
+// station/section labels round-tripped through getAttribute(), which decodes
+// the SVG's own HTML-escaped entities) before it lands in an innerHTML
+// template literal.
+function escapeHtml(str) {
+  return String(str).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+}
+
 function attachMetroMap(opts) {
   const root = opts.root;
   const lines = opts.lines;
@@ -192,8 +202,8 @@ function attachMetroMap(opts) {
     chip.className = 'nf-metro-chip';
     chip.dataset.lineId = ln.id;
     chip.innerHTML =
-      `<div class="nf-metro-swatch" style="background:${ln.color}"></div>` +
-      `<span>${ln.label}</span>`;
+      `<div class="nf-metro-swatch" style="background:${escapeHtml(ln.color)}"></div>` +
+      `<span>${escapeHtml(ln.label)}</span>`;
     chip.addEventListener('click', () => setActiveLine(ln.id));
     legend.appendChild(chip);
   });
@@ -214,11 +224,11 @@ function attachMetroMap(opts) {
       const ln = linesById.get(id);
       if (!ln) return '';
       return `<div class="nf-metro-tt-line">` +
-        `<div class="nf-metro-swatch" style="background:${ln.color}"></div>` +
-        `${ln.label}</div>`;
+        `<div class="nf-metro-swatch" style="background:${escapeHtml(ln.color)}"></div>` +
+        `${escapeHtml(ln.label)}</div>`;
     }).join('');
-    return `<div class="nf-metro-tt-title">${label}</div>` +
-      (section ? `<div class="nf-metro-tt-section">${section}</div>` : '') +
+    return `<div class="nf-metro-tt-title">${escapeHtml(label)}</div>` +
+      (section ? `<div class="nf-metro-tt-section">${escapeHtml(section)}</div>` : '') +
       lineHtml;
   }
   function positionTip(e) {

--- a/src/nf_metro/render/html.py
+++ b/src/nf_metro/render/html.py
@@ -100,32 +100,33 @@ def emit_render_plan_html(
     snippet_id = "m" + hashlib.sha1(svg.encode("utf-8")).hexdigest()[:8]
     inline_snippet = _build_inline_snippet(svg, lines, snippet_id)
 
-    # Browsers terminate the outer <script> the moment they see literal
-    # </script>, regardless of JS string context. JSON's optional `\/`
-    # escape decodes back to `/`, so the snippet survives round-trip. `lines`
-    # carries directive-authored text (line colour/label), so the same
-    # protection applies to its embedded JSON literal.
-    inline_snippet_json = json.dumps(inline_snippet).replace("</", "<\\/")
-
     return _STANDALONE_TEMPLATE.substitute(
         title=html.escape(title),
         svg=svg,
-        lines_json=_lines_json(lines),
+        lines_json=_script_safe_json(lines),
         embed_basename=html.escape(embed_basename),
-        inline_snippet_json=inline_snippet_json,
+        inline_snippet_json=_script_safe_json(inline_snippet),
         shared_js=get_driver_js(),
     )
 
 
-def _lines_json(lines: list[dict[str, str]]) -> str:
-    """JSON-encode *lines* for embedding as a JS literal inside ``<script>``."""
-    return json.dumps(lines).replace("</", "<\\/")
+def _script_safe_json(value: list[dict[str, str]] | str) -> str:
+    """JSON-encode *value* for embedding as a JS literal inside ``<script>``.
+
+    Browsers terminate the outer ``<script>`` the moment they see literal
+    ``</script>``, regardless of JS string context. JSON's optional ``\\/``
+    escape decodes back to ``/``, so the embedded literal survives round-trip.
+    This is the one chokepoint every ``<script>``-embedded JSON value in this
+    module goes through, since some of those values (line colours/labels,
+    the inline snippet's own SVG) carry directive-authored text.
+    """
+    return json.dumps(value).replace("</", "<\\/")
 
 
 def _build_inline_snippet(svg: str, lines: list[dict[str, str]], sid: str) -> str:
     return _INLINE_TEMPLATE.substitute(
         sid=sid,
         svg=svg,
-        lines_json=_lines_json(lines),
+        lines_json=_script_safe_json(lines),
         shared_js=get_driver_js(),
     )

--- a/src/nf_metro/render/html.py
+++ b/src/nf_metro/render/html.py
@@ -102,23 +102,30 @@ def emit_render_plan_html(
 
     # Browsers terminate the outer <script> the moment they see literal
     # </script>, regardless of JS string context. JSON's optional `\/`
-    # escape decodes back to `/`, so the snippet survives round-trip.
+    # escape decodes back to `/`, so the snippet survives round-trip. `lines`
+    # carries directive-authored text (line colour/label), so the same
+    # protection applies to its embedded JSON literal.
     inline_snippet_json = json.dumps(inline_snippet).replace("</", "<\\/")
 
     return _STANDALONE_TEMPLATE.substitute(
         title=html.escape(title),
         svg=svg,
-        lines_json=json.dumps(lines),
+        lines_json=_lines_json(lines),
         embed_basename=html.escape(embed_basename),
         inline_snippet_json=inline_snippet_json,
         shared_js=get_driver_js(),
     )
 
 
+def _lines_json(lines: list[dict[str, str]]) -> str:
+    """JSON-encode *lines* for embedding as a JS literal inside ``<script>``."""
+    return json.dumps(lines).replace("</", "<\\/")
+
+
 def _build_inline_snippet(svg: str, lines: list[dict[str, str]], sid: str) -> str:
     return _INLINE_TEMPLATE.substitute(
         sid=sid,
         svg=svg,
-        lines_json=json.dumps(lines),
+        lines_json=_lines_json(lines),
         shared_js=get_driver_js(),
     )

--- a/src/nf_metro/render/legend.py
+++ b/src/nf_metro/render/legend.py
@@ -16,6 +16,7 @@ __all__ = [
 ]
 
 import base64
+import binascii
 import html
 from dataclasses import dataclass
 from io import BytesIO
@@ -98,14 +99,32 @@ def resolve_logo_file(raw: str, source_dir: str) -> str:
 
 
 def open_logo_image(path: str) -> "PILImageType":
-    """Open a logo image from a data URI or a file path."""
+    """Open a logo image from a data URI or a file path.
+
+    Raises ``ValueError`` for a data URI whose payload cannot be decoded and
+    opened as an image, rather than letting a malformed or truncated payload
+    surface a raw ``binascii``/PIL exception to the caller. Decoding is
+    strict (``validate=True``): a payload byte outside the base64 alphabet
+    is rejected outright rather than silently discarded, since Python's
+    lenient (default) decoder would otherwise skip such bytes and decode
+    whatever remains - an outcome that depends on incidental byte-length
+    arithmetic rather than on whether the payload is well-formed.
+    """
     from PIL import Image as PILImage
+    from PIL import UnidentifiedImageError
 
     if path.startswith("data:"):
         header, _, payload = path.partition(",")
         if ";base64" not in header:
             raise ValueError("logo data URI must be base64-encoded")
-        return PILImage.open(BytesIO(base64.b64decode(payload)))
+        try:
+            decoded = base64.b64decode(payload, validate=True)
+            return PILImage.open(BytesIO(decoded))
+        except (binascii.Error, UnidentifiedImageError, OSError) as exc:
+            raise ValueError(
+                "logo data URI's base64 payload could not be decoded as an "
+                f"image: {exc}"
+            ) from exc
     return PILImage.open(path)
 
 

--- a/src/nf_metro/render/legend.py
+++ b/src/nf_metro/render/legend.py
@@ -16,6 +16,7 @@ __all__ = [
 ]
 
 import base64
+import html
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
@@ -112,10 +113,13 @@ def logo_image_kwargs(path: str) -> dict[str, str | bool]:
     """``drawsvg.Image`` kwargs that embed a logo from a data URI or file path.
 
     A data URI is already a self-contained ``data:`` href, so it is passed
-    through unembedded; a file path is read and base64-embedded as usual.
+    through unembedded (HTML-escaped, since it is directive-authored text
+    landing verbatim in an ``xlink:href`` attribute); a file path is read and
+    base64-embedded as usual, where drawsvg generates its own href from the
+    decoded bytes.
     """
     if path.startswith("data:"):
-        return {"path": path, "embed": False}
+        return {"path": html.escape(path), "embed": False}
     return {"path": path, "embed": True}
 
 
@@ -124,7 +128,9 @@ def marker_fill_color(fill: str, theme: Theme) -> str:
 
     ``open`` renders the theme's open-marker interior (falling back to the
     background, or white on transparent themes); ``solid`` uses the default
-    station fill; anything else is taken as a literal colour.
+    station fill; anything else is taken as a literal colour, directive-
+    authored text that is HTML-escaped here before it lands in an SVG
+    attribute (a no-op on every legitimate CSS colour form).
     """
     if fill == MARKER_FILL_OPEN:
         if theme.marker_open_fill:
@@ -134,7 +140,7 @@ def marker_fill_color(fill: str, theme: Theme) -> str:
         return "#ffffff"
     if fill == MARKER_FILL_SOLID:
         return theme.station_fill
-    return fill
+    return html.escape(fill)
 
 
 def marker_corner_radius(shape: str, r: float) -> float:

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -116,6 +116,61 @@ def test_render_html_closing_script_tag_escaped(tmp_path):
     assert "<\\/script>" in content
 
 
+def test_render_html_lines_json_escapes_script_close_in_label():
+    """A line label containing a literal ``</script>`` must not terminate the
+    outer ``<script>`` block that embeds the ``lines`` JSON early.
+
+    The rendered SVG separately carries the manifest as ``<metadata>`` CDATA,
+    where the same raw text is inert (CDATA sections are immune to
+    ``</script>`` in SVG foreign content), so the assertion is scoped to the
+    ``lines: [...]`` JS literal rather than the whole page.
+    """
+    graph = parse_metro_mermaid(
+        "%%metro line: evil | </script><script>alert(1)</script> | #ff0000\n"
+        "graph LR\n    a[A] -->|evil| b[B]\n"
+    )
+    compute_layout(graph)
+    html_out = render_html(graph, THEMES["nfcore"])
+
+    match = re.search(r"lines: (\[.*?\]),\n  embed:", html_out)
+    assert match, "expected a `lines: [...]` JS literal in the standalone page"
+    lines_literal = match.group(1)
+    assert "</script>" not in lines_literal
+    assert "<\\/script>" in lines_literal
+
+
+DRIVER_JS = (
+    Path(__file__).resolve().parent.parent / "src" / "nf_metro" / "render" / "driver.js"
+)
+
+
+def test_driver_js_escapes_untrusted_values_at_every_dom_sink():
+    """driver.js re-reads ``getAttribute()``-sourced labels (which decode the
+    SVG's own HTML-escaped entities) and line colour/label from the embedded
+    ``lines`` JSON, then inserts both via ``innerHTML``; upstream Python-side
+    escaping cannot protect that path, so this checks the source directly for
+    the escaping helper being applied at each sink.
+
+    This repo has no JS test runner wired up, so a source-inspection
+    assertion is the fallback in place of an executed DOM test.
+    """
+    src = DRIVER_JS.read_text()
+    assert "function escapeHtml(" in src
+
+    chip_html = re.search(r"chip\.innerHTML =\n?(.*?);", src, re.DOTALL)
+    assert chip_html, "expected the legend chip's innerHTML assignment"
+    assert "escapeHtml(ln.color)" in chip_html.group(1)
+    assert "escapeHtml(ln.label)" in chip_html.group(1)
+
+    build_tip = re.search(r"function buildTip\(rect\) \{(.*?)\n  \}", src, re.DOTALL)
+    assert build_tip, "expected the tooltip-building function"
+    body = build_tip.group(1)
+    assert "escapeHtml(label)" in body
+    assert "escapeHtml(section)" in body
+    assert "escapeHtml(ln.color)" in body
+    assert "escapeHtml(ln.label)" in body
+
+
 def test_render_html_embedded_svg_matches_standalone_render():
     """Embedded SVG matches the canonical legend-less SVG render for the input."""
     text = RNASEQ_MMD.read_text()

--- a/tests/test_mode_adaptive_logo.py
+++ b/tests/test_mode_adaptive_logo.py
@@ -3,7 +3,6 @@
 import base64
 import io
 import re
-import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
@@ -261,6 +260,15 @@ def test_open_logo_image_rejects_non_base64_data_uri():
         open_logo_image("data:image/png,not-base64")
 
 
+def test_open_logo_image_rejects_corrupt_base64_payload():
+    """A well-formed ``;base64,`` header with a payload that fails to decode
+    (e.g. bytes appended after the legitimate base64 alphabet) raises a
+    ``ValueError`` rather than an unhandled ``binascii.Error``."""
+    corrupt = _png_data_uri(width=40, height=20) + '" onerror="alert(1)'
+    with pytest.raises(ValueError, match="base64"):
+        open_logo_image(corrupt)
+
+
 def test_resolve_logo_accepts_data_uri_single_path():
     """A data URI needs no filesystem access, so it resolves with no source_dir."""
     g = MetroGraph()
@@ -321,10 +329,14 @@ def test_logo_image_kwargs_escapes_quote_in_data_uri():
     assert "&quot;" in kwargs["path"]
 
 
-def test_data_uri_logo_with_quote_does_not_break_out_of_href():
-    """A data URI is directive-authored text landing verbatim in an
-    ``xlink:href`` attribute, so a literal ``"`` in it must not escape that
-    attribute's quoting."""
+def test_data_uri_logo_with_quote_is_rejected_before_rendering():
+    """Appending an attack suffix to a data-URI logo's base64 payload
+    corrupts it; ``open_logo_image`` (via ``compute_logo_dimensions``,
+    called while resolving the logo) rejects that corrupt payload with a
+    ``ValueError`` before any rendering happens, rather than letting the
+    corrupt bytes reach ``PIL.Image.open`` unguarded, or letting a
+    malformed-but-decodable payload's escaped text reach SVG attribute
+    emission with no dimensions computed for it."""
     malicious = _png_data_uri(width=40, height=20) + '" onerror="alert(1)'
     text = (
         f"%%metro logo: {malicious}\n"
@@ -333,9 +345,5 @@ def test_data_uri_logo_with_quote_does_not_break_out_of_href():
         "    a[A] -->|main| b[B]\n"
     )
 
-    svg = render_string(text, chrome_css=False)
-
-    root = ET.fromstring(svg)
-    for el in root.iter():
-        assert "onerror" not in el.attrib, f"{el.tag} attrib={el.attrib}"
-    assert "alert(1)" in svg
+    with pytest.raises(ValueError, match="base64"):
+        render_string(text, chrome_css=False)

--- a/tests/test_mode_adaptive_logo.py
+++ b/tests/test_mode_adaptive_logo.py
@@ -3,6 +3,7 @@
 import base64
 import io
 import re
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
@@ -10,7 +11,11 @@ from PIL import Image as PILImage
 
 from nf_metro.api import render_string
 from nf_metro.parser.model import MetroGraph
-from nf_metro.render.legend import logo_is_resolvable, open_logo_image
+from nf_metro.render.legend import (
+    logo_image_kwargs,
+    logo_is_resolvable,
+    open_logo_image,
+)
 from nf_metro.render.ns import adaptive_logo_mask_ids as _adaptive_logo_mask_ids
 from nf_metro.render.svg import (
     _effective_logo_path,
@@ -305,3 +310,32 @@ def test_baked_mode_embeds_matching_logo_variant(tmp_path):
 
     assert _embedded_image_bytes(light_svg) == light_file.read_bytes()
     assert _embedded_image_bytes(dark_svg) == dark_file.read_bytes()
+
+
+def test_logo_image_kwargs_escapes_quote_in_data_uri():
+    malicious = _png_data_uri() + '" onerror="alert(1)'
+    kwargs = logo_image_kwargs(malicious)
+
+    assert kwargs["embed"] is False
+    assert '"' not in kwargs["path"]
+    assert "&quot;" in kwargs["path"]
+
+
+def test_data_uri_logo_with_quote_does_not_break_out_of_href():
+    """A data URI is directive-authored text landing verbatim in an
+    ``xlink:href`` attribute, so a literal ``"`` in it must not escape that
+    attribute's quoting."""
+    malicious = _png_data_uri(width=40, height=20) + '" onerror="alert(1)'
+    text = (
+        f"%%metro logo: {malicious}\n"
+        "%%metro line: main | Main | #0570b0\n"
+        "graph LR\n"
+        "    a[A] -->|main| b[B]\n"
+    )
+
+    svg = render_string(text, chrome_css=False)
+
+    root = ET.fromstring(svg)
+    for el in root.iter():
+        assert "onerror" not in el.attrib, f"{el.tag} attrib={el.attrib}"
+    assert "alert(1)" in svg

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1502,3 +1502,31 @@ def test_redeclared_line_id_keeps_the_first_declaration():
         graph = parse_metro_mermaid(src)
     assert graph.lines["l1"].display_name == "First"
     assert graph.lines["l1"].color == "#ff0000"
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        'evil" onload="alert(1)',
+        "has space",
+        "<script>",
+        "1starts-with-digit",
+    ],
+)
+def test_line_declaration_with_an_id_outside_the_identifier_charset_is_rejected(
+    bad_id,
+):
+    """A line id lands in SVG class/data-* attributes verbatim, so it is
+    constrained to the same charset as node/section ids at declaration time."""
+    src = f"%%metro line: {bad_id} | Name | #ff0000\ngraph LR\n    a[A] -->|x| b[B]\n"
+    with pytest.raises(ValueError, match=r"\[a-zA-Z_\]\[a-zA-Z0-9_\]\*"):
+        parse_metro_mermaid(src)
+
+
+def test_line_declaration_with_a_valid_identifier_id_is_accepted():
+    src = (
+        "%%metro line: valid_id1 | Name | #ff0000\n"
+        "graph LR\n    a[A] -->|valid_id1| b[B]\n"
+    )
+    graph = parse_metro_mermaid(src)
+    assert "valid_id1" in graph.lines

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1517,10 +1517,17 @@ def test_line_declaration_with_an_id_outside_the_identifier_charset_is_rejected(
     bad_id,
 ):
     """A line id lands in SVG class/data-* attributes verbatim, so it is
-    constrained to the same charset as node/section ids at declaration time."""
-    src = f"%%metro line: {bad_id} | Name | #ff0000\ngraph LR\n    a[A] -->|x| b[B]\n"
-    with pytest.raises(ValueError, match=r"\[a-zA-Z_\]\[a-zA-Z0-9_\]\*"):
-        parse_metro_mermaid(src)
+    constrained to the same charset as node/section ids at declaration time.
+    A rejected declaration is skipped (like every other malformed ``line:``
+    field), so the id is simply never declared; an edge that references it
+    is caught by the undeclared-line check instead."""
+    src = (
+        f"%%metro line: {bad_id} | Name | #ff0000\n"
+        f"graph LR\n    a[A] -->|{bad_id}| b[B]\n"
+    )
+    with pytest.warns(UserWarning, match=r"\[a-zA-Z_\]\[a-zA-Z0-9_\]\*"):
+        with pytest.raises(ValueError, match="undeclared metro lines"):
+            parse_metro_mermaid(src)
 
 
 def test_line_declaration_with_a_valid_identifier_id_is_accepted():

--- a/tests/test_svg_attribute_escaping.py
+++ b/tests/test_svg_attribute_escaping.py
@@ -1,0 +1,83 @@
+"""Directive-authored text (line colours, marker fills) reaches SVG attribute
+values verbatim through drawsvg, which escapes element text content but not
+attribute values. A literal ``"`` in one of these values must not break out
+of its attribute; ``html.escape`` at the two chokepoints
+(``effective_line_color`` / ``marker_fill_color``) closes that off.
+"""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.render.svg import render_svg
+from nf_metro.themes import NFCORE_DARK_THEME
+
+_BREAKOUT = 'red" onload="alert(1)'
+
+
+def _no_injected_attribute(svg: str) -> None:
+    root = ET.fromstring(svg)
+    for el in root.iter():
+        assert "onload" not in el.attrib, f"{el.tag} attrib={el.attrib}"
+
+
+def test_line_color_breakout_is_escaped_in_edge_and_legend_swatch():
+    src = (
+        "%%metro title: Test\n"
+        f"%%metro line: evil | Evil | {_BREAKOUT}\n"
+        "graph LR\n"
+        "    a[Input]\n"
+        "    b[Output]\n"
+        "    a -->|evil| b\n"
+    )
+    graph = parse_metro_mermaid(src)
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
+
+    _no_injected_attribute(svg)
+    assert "alert(1)" in svg
+    assert 'onload="alert(1)"' not in svg
+
+
+def test_marker_fill_breakout_is_escaped_in_station_and_marker_legend():
+    src = (
+        "%%metro title: Test\n"
+        "%%metro line: main | Main | #4caf50\n"
+        f"%%metro marker: a | circle, {_BREAKOUT}\n"
+        f"%%metro marker_legend: circle, {_BREAKOUT} | Caption\n"
+        "graph LR\n"
+        "    a[Input]\n"
+        "    b[Output]\n"
+        "    a -->|main| b\n"
+    )
+    graph = parse_metro_mermaid(src)
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
+
+    _no_injected_attribute(svg)
+    assert "alert(1)" in svg
+    assert 'onload="alert(1)"' not in svg
+
+
+@pytest.mark.parametrize(
+    "color",
+    ["#4caf50", "red", "rgb(1,2,3)", "var(--x)", "light-dark(#fff,#000)"],
+)
+def test_legitimate_colors_render_unescaped(color):
+    """html.escape must be a no-op on every legitimate CSS colour form."""
+    src = (
+        "%%metro title: Test\n"
+        f"%%metro line: main | Main | {color}\n"
+        "graph LR\n"
+        "    a[Input]\n"
+        "    b[Output]\n"
+        "    a -->|main| b\n"
+    )
+    graph = parse_metro_mermaid(src)
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_DARK_THEME)
+
+    assert color in svg
+    assert "&amp;" not in svg


### PR DESCRIPTION
## Summary
- Escape `%%metro line:` colors and marker fill values at their single resolver chokepoints (`effective_line_color()`, `marker_fill_color()`) before they reach SVG `stroke=`/`fill=` attributes, closing an attribute-injection vector (a value like `red" onload="alert(1)` previously broke out of its attribute).
- Constrain `%%metro line:` declared ids to the same safe identifier charset already used for node/section/station ids; a malformed id is warned-and-skipped rather than declared, so it's caught by the existing undeclared-line-reference check if referenced by an edge.
- Escape the `%%metro logo:` `data:` URI before it reaches `xlink:href`, and make `open_logo_image()` reject a corrupt/malformed base64 payload deterministically (`validate=True`) with a clear `ValueError` instead of an unhandled `binascii.Error`/decode crash.
- Fix the interactive HTML playground's DOM-XSS surface: `driver.js` now escapes untrusted values (line color, line label, and `getAttribute()`-sourced station/section labels) before inserting them via `innerHTML`, since the SVG's own `html.escape()`-encoded attributes get decoded by `getAttribute()` and would otherwise be re-injected unescaped.
- Close a `</script>`-breakout gap in the JSON blob embedded in the playground's inline `<script>` block (`render/html.py`), unifying it with the existing escaping used for the inline snippet JSON at one shared helper.
- Dedup the identifier-charset regex between the parser directive validator and the Lark grammar's `NAME` token, and the script-safe-JSON escaping helper across all three embed sites, so each has one source of truth.

Fixes #1908

## Test plan
- [x] Targeted tests pass locally (parser, render/constants, render/legend, render/html, new `test_svg_attribute_escaping.py`, `test_mode_adaptive_logo.py`), plus a broader parser/render/legend/html/logo/svg sanity sweep (4987 tests) — all green
- [x] `ruff check` + `ruff format --check` clean on touched Python files
- [x] No regression to legitimate rendering: colors like `#4caf50`, `var(--x)`, `light-dark(#fff,#000)`, `rgb(1,2,3)` render unchanged (html.escape is a no-op on them); `examples/rnaseq_sections.mmd` byte-identical to main
- [x] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1926/): CI render-diff reports zero deltas across the whole gallery corpus
- [x] Render-preview verdict: No visual changes