### PR TITLE
fix(scripts): isolate render-diff panel stylesheets so cascade defects are visible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,8 @@ open /tmp/rnaseq_sections.png
 
 Any env with the project importable and `cairosvg` available works. Prefer pointing `PYTHONPATH` at the worktree you mean to test rather than an editable install, which binds one env to one worktree path and breaks when that worktree is pruned.
 
+`--no-chrome-css` bakes concrete colors and omits the chrome `<style>` block entirely, so this PNG cannot show a chrome-CSS cascade defect (a rule that repaints an element the stylesheet is supposed to leave alone). Answer cascade questions with the CI render-diff or a targeted test, not this recipe.
+
 ## Test Fixtures & Topology Stress Tests
 
 - Test fixtures: `tests/fixtures/`

--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -380,6 +380,9 @@ _WIDTH_RE = re.compile(r'\bwidth="(\d+)"')
 _HEIGHT_RE = re.compile(r'\bheight="(\d+)"')
 _ID_ATTR_RE = re.compile(r'\bid="([^"]+)"')
 _URL_REF_RE = re.compile(r"url\(#([^)]+)\)")
+_CLASS_ATTR_RE = re.compile(r'\bclass="([^"]*)"')
+_STYLE_BLOCK_RE = re.compile(r"(<style>)(.*?)(</style>)", re.DOTALL)
+_CLASS_SELECTOR_RE = re.compile(r"\.([A-Za-z_][\w-]*)")
 
 
 def _namespace_referenced_ids(content: str, namespace: str) -> str:
@@ -410,6 +413,38 @@ def _namespace_referenced_ids(content: str, namespace: str) -> str:
     return _URL_REF_RE.sub(repl_ref, content)
 
 
+def _namespace_presentation_classes(content: str, namespace: str) -> str:
+    """Suffix every presentation class name with *namespace*, in the
+    ``class="..."`` attribute tokens and in the selectors inside this panel's
+    own ``<style>`` block(s).
+
+    Inline SVG ``<style>`` in an HTML document is document-global, so two
+    inlined copies of the same pipeline (e.g. a base and a PR render) that use
+    the same class names let one copy's rule match the other copy's elements.
+    A rule present in only one panel's stylesheet then also selects the other
+    panel's identically-classed elements, silently repainting them and
+    masking a genuine stylesheet difference between the two renders.
+    Suffixing every class name per inlined copy keeps each copy's rules
+    matching only its own elements.
+
+    *namespace* must be unique per inlined copy on the page - see
+    :func:`_panel_namespace`.
+    """
+
+    def repl_attr(m: re.Match[str]) -> str:
+        tokens = m.group(1).split()
+        renamed = " ".join(f"{t}--{namespace}" for t in tokens)
+        return f'class="{renamed}"'
+
+    def repl_style(m: re.Match[str]) -> str:
+        open_tag, body, close_tag = m.group(1), m.group(2), m.group(3)
+        body = _CLASS_SELECTOR_RE.sub(rf".\g<1>--{namespace}", body)
+        return f"{open_tag}{body}{close_tag}"
+
+    content = _CLASS_ATTR_RE.sub(repl_attr, content)
+    return _STYLE_BLOCK_RE.sub(repl_style, content)
+
+
 def _panel_namespace(stem: str, side: str) -> str:
     """Build the per-panel namespace passed to :func:`_inline_svg`.
 
@@ -430,10 +465,12 @@ def _inline_svg(path: Path, namespace: str) -> str:
     Adding viewBox (when absent) enables proportional CSS scaling via max-width/height.
 
     *namespace* must be unique per inlined copy on the page (e.g. combining the
-    render's stem with "base"/"pr") - see :func:`_namespace_referenced_ids`.
+    render's stem with "base"/"pr") - see :func:`_namespace_referenced_ids` and
+    :func:`_namespace_presentation_classes`.
     """
     content = path.read_text()
     content = _namespace_referenced_ids(content, namespace)
+    content = _namespace_presentation_classes(content, namespace)
     m = _SVG_ROOT_RE.search(content)
     if not m:
         return content

--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -383,10 +383,13 @@ _URL_REF_RE = re.compile(r"url\(#([^)]+)\)")
 _CLASS_ATTR_RE = re.compile(r'(?<![\w-])class="([^"]*)"')
 _STYLE_BLOCK_RE = re.compile(r"(<style>)(.*?)(</style>)", re.DOTALL)
 _CLASS_SELECTOR_RE = re.compile(r"\.([A-Za-z_][\w-]*)")
-# The url(...) branch is tried first, so a dotted token inside a url(...) span
-# (e.g. a filename) is consumed whole and never reaches the class-selector
-# branch; only group(1) marks a real class-selector match.
-_STYLE_BODY_REWRITE_RE = re.compile(r"url\([^)]*\)|" + _CLASS_SELECTOR_RE.pattern)
+# The url(...) alternative is tried first, so a dotted filename inside a
+# simple url(...) span matches as part of that alternative instead of the
+# class-selector one. It does not account for nested parens, a quoted ")",
+# or an uppercase "URL(".
+_STYLE_BODY_REWRITE_RE = re.compile(
+    r"url\([^)]*\)|(?P<class_selector>" + _CLASS_SELECTOR_RE.pattern + ")"
+)
 
 
 def _namespace_referenced_ids(content: str, namespace: str) -> str:
@@ -441,9 +444,10 @@ def _namespace_presentation_classes(content: str, namespace: str) -> str:
         return f'class="{renamed}"'
 
     def repl_token(tm: re.Match[str]) -> str:
-        name = tm.group(1)
-        if name is None:  # a url(...) span, not a class selector
+        selector = tm.group("class_selector")
+        if selector is None:  # a url(...) span, not a class selector
             return tm.group(0)
+        name = selector[1:]  # drop the leading "."
         return f".{name}--{namespace}"
 
     def repl_style(m: re.Match[str]) -> str:

--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -383,6 +383,10 @@ _URL_REF_RE = re.compile(r"url\(#([^)]+)\)")
 _CLASS_ATTR_RE = re.compile(r'(?<![\w-])class="([^"]*)"')
 _STYLE_BLOCK_RE = re.compile(r"(<style>)(.*?)(</style>)", re.DOTALL)
 _CLASS_SELECTOR_RE = re.compile(r"\.([A-Za-z_][\w-]*)")
+# The url(...) branch is tried first, so a dotted token inside a url(...) span
+# (e.g. a filename) is consumed whole and never reaches the class-selector
+# branch; only group(1) marks a real class-selector match.
+_STYLE_BODY_REWRITE_RE = re.compile(r"url\([^)]*\)|" + _CLASS_SELECTOR_RE.pattern)
 
 
 def _namespace_referenced_ids(content: str, namespace: str) -> str:
@@ -436,9 +440,15 @@ def _namespace_presentation_classes(content: str, namespace: str) -> str:
         renamed = " ".join(f"{t}--{namespace}" for t in tokens)
         return f'class="{renamed}"'
 
+    def repl_token(tm: re.Match[str]) -> str:
+        name = tm.group(1)
+        if name is None:  # a url(...) span, not a class selector
+            return tm.group(0)
+        return f".{name}--{namespace}"
+
     def repl_style(m: re.Match[str]) -> str:
         open_tag, body, close_tag = m.group(1), m.group(2), m.group(3)
-        body = _CLASS_SELECTOR_RE.sub(rf".\g<1>--{namespace}", body)
+        body = _STYLE_BODY_REWRITE_RE.sub(repl_token, body)
         return f"{open_tag}{body}{close_tag}"
 
     content = _CLASS_ATTR_RE.sub(repl_attr, content)

--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -380,7 +380,7 @@ _WIDTH_RE = re.compile(r'\bwidth="(\d+)"')
 _HEIGHT_RE = re.compile(r'\bheight="(\d+)"')
 _ID_ATTR_RE = re.compile(r'\bid="([^"]+)"')
 _URL_REF_RE = re.compile(r"url\(#([^)]+)\)")
-_CLASS_ATTR_RE = re.compile(r'\bclass="([^"]*)"')
+_CLASS_ATTR_RE = re.compile(r'(?<![\w-])class="([^"]*)"')
 _STYLE_BLOCK_RE = re.compile(r"(<style>)(.*?)(</style>)", re.DOTALL)
 _CLASS_SELECTOR_RE = re.compile(r"\.([A-Za-z_][\w-]*)")
 

--- a/tests/test_render_diff_inline_svg_ids.py
+++ b/tests/test_render_diff_inline_svg_ids.py
@@ -1,13 +1,14 @@
-"""Regression test: duplicate SVG ids across inlined render-diff panels.
+"""Regression tests for cross-panel contamination in inlined render-diff panels.
 
 The render-diff page (``scripts/build_render_diff.py``) inlines two copies of
-the same pipeline's SVG side by side (base + PR). When both copies share the
-same source (e.g. the mask markup is byte-identical), their ``id``s collide.
-The base/PR/side-by-side toggle buttons switch panels via ``display:none``,
-and a browser resolving ``url(#id)`` picks the first same-id element in
-document order - if that first element sits inside a now-hidden subtree, the
-reference stops working and the mask is dropped entirely, so both the light
-and dark logo variants render unmasked on top of each other.
+the same pipeline's SVG side by side (base + PR) into one HTML document.
+Inline SVG ``id`` scope and ``<style>`` scope are both document-global, so two
+panels sharing an ``id`` or a presentation class name apply to each other: a
+``url(#id)`` reference in a hidden panel (the base/PR/side-by-side toggle
+buttons switch panels via ``display:none``) resolves into a visible panel's
+element, and a CSS rule in one panel's stylesheet matches the other panel's
+identically-classed elements. Both effects mask a genuine difference between
+the base and PR renders that the diff page exists to surface.
 """
 
 from __future__ import annotations
@@ -19,13 +20,18 @@ from pathlib import Path
 from nf_metro.api import render_string
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from build_render_diff import (  # noqa: E402
+    _CLASS_ATTR_RE,
+    _CLASS_SELECTOR_RE,
+    _STYLE_BLOCK_RE,
+    _URL_REF_RE,
+    _inline_svg,
+    build_diff,
+)
 from build_render_diff import _ID_ATTR_RE as _ID_RE  # noqa: E402
-from build_render_diff import _URL_REF_RE, _inline_svg, build_diff  # noqa: E402
 
 EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
 
-_CLASS_ATTR_TOKENS_RE = re.compile(r'class="([^"]*)"')
-_STYLE_SELECTOR_TOKEN_RE = re.compile(r"\.([A-Za-z_][\w-]*)")
 _MUTED_RULE_PAIR_RE = re.compile(
     r"\.nf-metro-station-label\.nf-metro-muted\s*\{[^}]*\}\n?"
     r"\.nf-metro-marker-stroke\.nf-metro-muted\s*\{[^}]*\}\n?"
@@ -51,7 +57,7 @@ def _strip_muted_rule(svg_text: str) -> str:
 def _classes_used_by_elements(fragment: str) -> set[str]:
     """Every class token that appears on an element in *fragment*."""
     tokens: set[str] = set()
-    for m in _CLASS_ATTR_TOKENS_RE.finditer(fragment):
+    for m in _CLASS_ATTR_RE.finditer(fragment):
         tokens.update(m.group(1).split())
     return tokens
 
@@ -59,9 +65,20 @@ def _classes_used_by_elements(fragment: str) -> set[str]:
 def _classes_named_in_style_selectors(fragment: str) -> set[str]:
     """Every class name a selector inside *fragment*'s <style> block(s) references."""
     names: set[str] = set()
-    for style_match in re.finditer(r"<style>(.*?)</style>", fragment, re.DOTALL):
-        names.update(_STYLE_SELECTOR_TOKEN_RE.findall(style_match.group(1)))
+    for style_match in _STYLE_BLOCK_RE.finditer(fragment):
+        names.update(_CLASS_SELECTOR_RE.findall(style_match.group(2)))
     return names
+
+
+def _assert_no_cross_panel_class_match(selector_side: str, class_side: str) -> None:
+    """Fail if *selector_side*'s <style> block selects any element in *class_side*."""
+    selectors = _classes_named_in_style_selectors(selector_side)
+    classes = _classes_used_by_elements(class_side)
+    matched = selectors & classes
+    assert not matched, (
+        f"one panel's <style> selects the other panel's element(s) via shared "
+        f"class name(s) {matched}"
+    )
 
 
 def _render_adaptive_logo_svg() -> str:
@@ -138,16 +155,7 @@ def test_build_diff_output_has_no_id_collisions(tmp_path):
 
 
 def test_one_panels_stylesheet_cannot_select_the_other_panels_elements(tmp_path):
-    """A CSS rule scoped to one panel's ``<style>`` block must not match the
-    other panel's elements once both share one HTML document.
-
-    Constructs a base/PR pair where only the base copy carries the
-    ``nf-metro-muted`` rule; the PR copy's markup applies the class with no
-    local rule to give it meaning. Inline SVG ``<style>`` is document-global,
-    so an un-namespaced base rule matches the PR panel's identically-classed
-    elements too, silently repainting them and masking the very stylesheet
-    difference the two panels exist to surface.
-    """
+    """A rule in one panel's <style> block must not select the other's elements."""
     svg_text = _render_inactive_lines_svg()
     defective_svg_text = _strip_muted_rule(svg_text)
 
@@ -159,28 +167,36 @@ def test_one_panels_stylesheet_cannot_select_the_other_panels_elements(tmp_path)
     base_inlined = _inline_svg(base_path, "inactive_lines-base")
     pr_inlined = _inline_svg(pr_path, "inactive_lines-pr")
 
-    base_selectors = _classes_named_in_style_selectors(base_inlined)
-    pr_classes = _classes_used_by_elements(pr_inlined)
-    matched = base_selectors & pr_classes
-    assert not matched, (
-        f"base panel's <style> selects PR panel element(s) via shared class "
-        f"name(s) {matched}"
-    )
-
-    pr_selectors = _classes_named_in_style_selectors(pr_inlined)
-    base_classes = _classes_used_by_elements(base_inlined)
-    matched = pr_selectors & base_classes
-    assert not matched, (
-        f"PR panel's <style> selects base panel element(s) via shared class "
-        f"name(s) {matched}"
-    )
+    _assert_no_cross_panel_class_match(base_inlined, pr_inlined)
+    _assert_no_cross_panel_class_match(pr_inlined, base_inlined)
 
 
-def test_build_diff_isolates_each_panels_css_and_leaves_the_corpus_untouched(tmp_path):
-    """End-to-end: a genuine stylesheet difference between base and PR renders
-    is not masked once both are inlined onto the same diff page, and the
-    on-disk corpus SVGs the change-detection gate compares are untouched by
-    page generation."""
+def test_build_diff_output_isolates_panel_stylesheets(tmp_path):
+    """The diff page must not let one panel's <style> select the other's elements."""
+    svg_text = _render_inactive_lines_svg()
+    defective_svg_text = _strip_muted_rule(svg_text)
+
+    base_dir = tmp_path / "base"
+    pr_dir = tmp_path / "pr"
+    base_dir.mkdir()
+    pr_dir.mkdir()
+    (base_dir / "inactive_lines.svg").write_text(svg_text)
+    (pr_dir / "inactive_lines.svg").write_text(defective_svg_text)
+
+    output_dir = tmp_path / "out"
+    assert build_diff(base_dir, pr_dir, output_dir)
+
+    page = (output_dir / "index.html").read_text()
+    base_start = page.index('class="side side-base"')
+    pr_start = page.index('class="side side-pr"')
+    side_base = page[base_start:pr_start]
+    side_pr = page[pr_start:]
+
+    _assert_no_cross_panel_class_match(side_base, side_pr)
+
+
+def test_build_diff_leaves_corpus_svgs_byte_unchanged(tmp_path):
+    """Generating the diff page must not modify the on-disk SVGs the gate compares."""
     svg_text = _render_inactive_lines_svg()
     defective_svg_text = _strip_muted_rule(svg_text)
 
@@ -198,17 +214,3 @@ def test_build_diff_isolates_each_panels_css_and_leaves_the_corpus_untouched(tmp
 
     assert base_svg_path.read_text() == svg_text
     assert pr_svg_path.read_text() == defective_svg_text
-
-    page = (output_dir / "index.html").read_text()
-    base_start = page.index('class="side side-base"')
-    pr_start = page.index('class="side side-pr"')
-    side_base = page[base_start:pr_start]
-    side_pr = page[pr_start:]
-
-    base_selectors = _classes_named_in_style_selectors(side_base)
-    pr_classes = _classes_used_by_elements(side_pr)
-    matched = base_selectors & pr_classes
-    assert not matched, (
-        f"base panel's <style> selects PR panel element(s) via shared class "
-        f"name(s) {matched} on the generated diff page"
-    )

--- a/tests/test_render_diff_inline_svg_ids.py
+++ b/tests/test_render_diff_inline_svg_ids.py
@@ -195,6 +195,35 @@ def test_build_diff_output_isolates_panel_stylesheets(tmp_path):
     _assert_no_cross_panel_class_match(side_base, side_pr)
 
 
+def test_style_block_url_with_dotted_filename_survives_class_rewrite(tmp_path):
+    """A dotted filename inside url(...) is not a class selector, so the
+    <style> rewrite must leave it verbatim while namespacing the surrounding
+    selectors and their matching class attributes together."""
+    svg_text = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">\n'
+        "<style>.nf-metro-bg { fill: url(sprite.png); }\n"
+        ".nf-metro-title { fill: #111; }</style>\n"
+        '<rect class="nf-metro-bg" />\n'
+        '<text class="nf-metro-title">Hi</text>\n'
+        "</svg>"
+    )
+    path = tmp_path / "synthetic.svg"
+    path.write_text(svg_text)
+
+    inlined = _inline_svg(path, "synthetic-pr")
+
+    assert "url(sprite.png)" in inlined
+
+    style_match = re.search(r"<style>(.*?)</style>", inlined, re.DOTALL)
+    assert style_match
+    style_body = style_match.group(1)
+    assert ".nf-metro-bg--synthetic-pr {" in style_body
+    assert ".nf-metro-title--synthetic-pr {" in style_body
+
+    assert 'class="nf-metro-bg--synthetic-pr"' in inlined
+    assert 'class="nf-metro-title--synthetic-pr"' in inlined
+
+
 def test_build_diff_leaves_corpus_svgs_byte_unchanged(tmp_path):
     """Generating the diff page must not modify the on-disk SVGs the gate compares."""
     svg_text = _render_inactive_lines_svg()

--- a/tests/test_render_diff_inline_svg_ids.py
+++ b/tests/test_render_diff_inline_svg_ids.py
@@ -12,6 +12,7 @@ and dark logo variants render unmasked on top of each other.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -22,6 +23,45 @@ from build_render_diff import _ID_ATTR_RE as _ID_RE  # noqa: E402
 from build_render_diff import _URL_REF_RE, _inline_svg, build_diff  # noqa: E402
 
 EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+_CLASS_ATTR_TOKENS_RE = re.compile(r'class="([^"]*)"')
+_STYLE_SELECTOR_TOKEN_RE = re.compile(r"\.([A-Za-z_][\w-]*)")
+_MUTED_RULE_PAIR_RE = re.compile(
+    r"\.nf-metro-station-label\.nf-metro-muted\s*\{[^}]*\}\n?"
+    r"\.nf-metro-marker-stroke\.nf-metro-muted\s*\{[^}]*\}\n?"
+)
+
+
+def _render_inactive_lines_svg() -> str:
+    text = (EXAMPLES / "inactive_lines.mmd").read_text()
+    return render_string(text, self_color_scheme=False)
+
+
+def _strip_muted_rule(svg_text: str) -> str:
+    """Delete the muted CSS rule pair from *svg_text*'s own stylesheet, leaving
+    its ``nf-metro-muted``-classed elements with no local rule to give that
+    class a meaning."""
+    stripped, n = _MUTED_RULE_PAIR_RE.subn("", svg_text)
+    assert n == 1, (
+        "fixture must declare the muted CSS rule pair for this test to be meaningful"
+    )
+    return stripped
+
+
+def _classes_used_by_elements(fragment: str) -> set[str]:
+    """Every class token that appears on an element in *fragment*."""
+    tokens: set[str] = set()
+    for m in _CLASS_ATTR_TOKENS_RE.finditer(fragment):
+        tokens.update(m.group(1).split())
+    return tokens
+
+
+def _classes_named_in_style_selectors(fragment: str) -> set[str]:
+    """Every class name a selector inside *fragment*'s <style> block(s) references."""
+    names: set[str] = set()
+    for style_match in re.finditer(r"<style>(.*?)</style>", fragment, re.DOTALL):
+        names.update(_STYLE_SELECTOR_TOKEN_RE.findall(style_match.group(1)))
+    return names
 
 
 def _render_adaptive_logo_svg() -> str:
@@ -95,3 +135,80 @@ def test_build_diff_output_has_no_id_collisions(tmp_path):
         assert defined_ids.count(ref) == 1, (
             f"id {ref!r} referenced by url(#{ref}) collides in the generated page"
         )
+
+
+def test_one_panels_stylesheet_cannot_select_the_other_panels_elements(tmp_path):
+    """A CSS rule scoped to one panel's ``<style>`` block must not match the
+    other panel's elements once both share one HTML document.
+
+    Constructs a base/PR pair where only the base copy carries the
+    ``nf-metro-muted`` rule; the PR copy's markup applies the class with no
+    local rule to give it meaning. Inline SVG ``<style>`` is document-global,
+    so an un-namespaced base rule matches the PR panel's identically-classed
+    elements too, silently repainting them and masking the very stylesheet
+    difference the two panels exist to surface.
+    """
+    svg_text = _render_inactive_lines_svg()
+    defective_svg_text = _strip_muted_rule(svg_text)
+
+    base_path = tmp_path / "inactive_lines.svg"
+    pr_path = tmp_path / "inactive_lines_pr.svg"
+    base_path.write_text(svg_text)
+    pr_path.write_text(defective_svg_text)
+
+    base_inlined = _inline_svg(base_path, "inactive_lines-base")
+    pr_inlined = _inline_svg(pr_path, "inactive_lines-pr")
+
+    base_selectors = _classes_named_in_style_selectors(base_inlined)
+    pr_classes = _classes_used_by_elements(pr_inlined)
+    matched = base_selectors & pr_classes
+    assert not matched, (
+        f"base panel's <style> selects PR panel element(s) via shared class "
+        f"name(s) {matched}"
+    )
+
+    pr_selectors = _classes_named_in_style_selectors(pr_inlined)
+    base_classes = _classes_used_by_elements(base_inlined)
+    matched = pr_selectors & base_classes
+    assert not matched, (
+        f"PR panel's <style> selects base panel element(s) via shared class "
+        f"name(s) {matched}"
+    )
+
+
+def test_build_diff_isolates_each_panels_css_and_leaves_the_corpus_untouched(tmp_path):
+    """End-to-end: a genuine stylesheet difference between base and PR renders
+    is not masked once both are inlined onto the same diff page, and the
+    on-disk corpus SVGs the change-detection gate compares are untouched by
+    page generation."""
+    svg_text = _render_inactive_lines_svg()
+    defective_svg_text = _strip_muted_rule(svg_text)
+
+    base_dir = tmp_path / "base"
+    pr_dir = tmp_path / "pr"
+    base_dir.mkdir()
+    pr_dir.mkdir()
+    base_svg_path = base_dir / "inactive_lines.svg"
+    pr_svg_path = pr_dir / "inactive_lines.svg"
+    base_svg_path.write_text(svg_text)
+    pr_svg_path.write_text(defective_svg_text)
+
+    output_dir = tmp_path / "out"
+    assert build_diff(base_dir, pr_dir, output_dir)
+
+    assert base_svg_path.read_text() == svg_text
+    assert pr_svg_path.read_text() == defective_svg_text
+
+    page = (output_dir / "index.html").read_text()
+    base_start = page.index('class="side side-base"')
+    pr_start = page.index('class="side side-pr"')
+    side_base = page[base_start:pr_start]
+    side_pr = page[pr_start:]
+
+    base_selectors = _classes_named_in_style_selectors(side_base)
+    pr_classes = _classes_used_by_elements(side_pr)
+    matched = base_selectors & pr_classes
+    assert not matched, (
+        f"base panel's <style> selects PR panel element(s) via shared class "
+        f"name(s) {matched} on the generated diff page"
+    )


### PR DESCRIPTION
Closes #1915.

## What this does

Namespaces presentation class names per panel when the render-diff page inlines its two SVGs, so one panel's chrome stylesheet can no longer style the other panel's elements.

## Why

The render-diff inlines the base and PR renders into a single HTML document. Inline-SVG `<style>` is document-global, and while `_namespace_referenced_ids` already prevents `url(#...)` id collisions, nothing rewrote **class names**. Both panels' chrome stylesheets therefore applied to both panels.

The effect is that a real stylesheet difference renders identically on each side. Demonstrated by removing the protective muted-label rule from one panel:

- `.nf-metro-station-label.nf-metro-muted { fill: ... #888888 }` exists only in the base panel's `<style>`.
- The defect panel's elements still carry `class="nf-metro-station-label nf-metro-muted"`, so that rule matches them across the panel boundary.
- Compound specificity (0,2,0) beats plain `.nf-metro-station-label` (0,1,0), and `fill=` presentation attributes lose to any matching rule.
- Both panels render `#888888`. Two different SVGs look the same.

The masking is symmetric, so both regression directions are hidden: removing a protective rule, or adding one that repaints.

This matters because CLAUDE.md designates the render-diff as the authoritative visual review.

## What was already fine

The automated change gate compares `read_bytes()` of the two SVG files. It is unaffected by this defect, catches stylesheet-only differences, and is independent of `light-dark()` mode. This PR does not change it, and adds a test pinning that the corpus SVGs stay byte-identical through page generation, since re-rendering panels with a class prefix would have broken exactly that.

Issue #1915's original diagnosis was inaccurate on several points; its body has been corrected in place. In short: chrome CSS is not gated on `self_color_scheme`, every corpus SVG does carry the chrome `<style>`, and the change gate was never blind.

## Implementation

- `_namespace_presentation_classes()` in `scripts/build_render_diff.py`, called from `_inline_svg` alongside the existing id namespacing. It rewrites both `class="..."` tokens and `<style>` selectors, reusing the per-panel namespace already in use for ids.
- The rewrite is a post-render text transform on the in-memory HTML only. The on-disk corpus SVGs are never touched.
- `_CLASS_ATTR_RE` tightened from `\b` to a `(?<![\w-])` lookbehind so it cannot match a hypothetical `data-class="..."`.
- The `<style>` rewrite tries a `url(...)` alternative before the class-selector branch, so a dotted filename inside a simple `url(...)` is not mistaken for a selector. Nested parens, a quoted `)`, and uppercase `URL(` fall outside that alternative and are still subject to the class rewrite; the renderer emits only base64 data URIs here, whose alphabet contains no `.`.
- Verified against the renderer's real CSS surface: compound selectors, multi-class attributes, substring class names, `@media` blocks, `var()` / `light-dark()` custom properties, base64 `@font-face` payloads, and the several separate `<style>` blocks a single SVG can carry.

## Tests

`tests/test_render_diff_inline_svg_ids.py` gains coverage that one panel's stylesheet cannot select the other panel's elements, that `build_diff` output isolates panel stylesheets, and that the corpus SVGs come through byte-unchanged. The first of these fails on the base commit. A further test pins that a `<style>` containing a `url(...)` with a dotted filename survives the rewrite intact while the selectors around it are still namespaced.

## Also

A note in CLAUDE.md that the local `--no-chrome-css` PNG recipe omits the chrome stylesheet and so cannot show a cascade defect. That behaviour is correct as designed (cairosvg cannot resolve the `var()` chrome properties), but it was undocumented as a review limitation.

## Deliberately not included

A generalised assertion that every chrome rule resolves to its intended winning declaration. PR #1911 already landed that shape for the muted case, and extending it across the whole stylesheet is a separate design question rather than fallout from this fix.

Rendering a second `self_color_scheme=True` corpus, floated in the issue, is rejected: it doubles render cost and does nothing about cross-panel contamination, which is the actual mechanism.
