### PR TITLE
fix(animate): reach forks behind non-canonical branches for ball paths

### DIFF
--- a/src/nf_metro/render/animate.py
+++ b/src/nf_metro/render/animate.py
@@ -6,6 +6,7 @@ __all__ = ["render_animation"]
 
 import math
 import re
+from collections import deque
 
 import drawsvg as draw
 
@@ -309,7 +310,42 @@ def _variant_path(
 ) -> list[Edge]:
     """Build a root-to-sink path that takes forced_edge at fork_node.
 
-    At every other fork, follows the first (canonical) branch.
+    The prefix from *start* to *fork_node* follows the first (canonical)
+    branch at every earlier fork. When that canonical walk cannot reach
+    *fork_node* -- because the only route to it runs through a non-first
+    branch at some earlier fork -- fall back to a breadth-first search over
+    the full adjacency to find any prefix that does. Without the fallback,
+    *forced_edge* is silently never emitted and its branch is dropped from
+    the animation.
+    """
+    prefix = _canonical_prefix_to(start, adj, fork_node)
+    if prefix is None:
+        prefix = _bfs_prefix_to(start, adj, fork_node)
+        if prefix is None:
+            return []
+
+    prefix_edges, visited = prefix
+    path = list(prefix_edges)
+    path.append(forced_edge)
+    current = forced_target
+    while current in adj and current not in visited:
+        visited.add(current)
+        target, edge = adj[current][0]
+        path.append(edge)
+        current = target
+    return path
+
+
+def _canonical_prefix_to(
+    start: str,
+    adj: dict[str, list[tuple[str, Edge]]],
+    fork_node: str,
+) -> tuple[list[Edge], set[str]] | None:
+    """Prefix from *start* to *fork_node* via the first branch at every fork.
+
+    Returns the prefix edges and the set of nodes visited (including
+    *fork_node*), or ``None`` if the canonical walk dead-ends before
+    reaching *fork_node*.
     """
     path: list[Edge] = []
     current = start
@@ -317,13 +353,37 @@ def _variant_path(
     while current in adj and current not in visited:
         visited.add(current)
         if current == fork_node:
-            path.append(forced_edge)
-            current = forced_target
-        else:
-            target, edge = adj[current][0]
-            path.append(edge)
-            current = target
-    return path
+            return path, visited
+        target, edge = adj[current][0]
+        path.append(edge)
+        current = target
+    return None
+
+
+def _bfs_prefix_to(
+    start: str,
+    adj: dict[str, list[tuple[str, Edge]]],
+    fork_node: str,
+) -> tuple[list[Edge], set[str]] | None:
+    """Shortest edge-path from *start* to *fork_node* over the full adjacency.
+
+    Returns the prefix edges and the set of nodes on that path (including
+    *fork_node*), or ``None`` if *fork_node* is unreachable from *start*.
+    """
+    queue: deque[tuple[str, list[Edge]]] = deque([(start, [])])
+    seen: set[str] = {start}
+    while queue:
+        node, edges = queue.popleft()
+        if node == fork_node:
+            visited = {start}
+            for edge in edges:
+                visited.add(edge.target)
+            return edges, visited
+        for target, edge in adj.get(node, []):
+            if target not in seen:
+                seen.add(target)
+                queue.append((target, [*edges, edge]))
+    return None
 
 
 def _chain_edge_points(

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -27,6 +27,7 @@ TOPOLOGIES_DIR = EXAMPLES_DIR / "topologies"
 ANIMATION_FIXTURES = [
     EXAMPLES_DIR / "genomeassembly.mmd",
     EXAMPLES_DIR / "rnaseq_sections.mmd",
+    EXAMPLES_DIR / "riboseq_metro.mmd",
     EXAMPLES_DIR / "epitopeprediction.mmd",
     EXAMPLES_DIR / "hlatyping.mmd",
     TOPOLOGIES_DIR / "fan_in_merge.mmd",
@@ -150,6 +151,61 @@ def test_motion_path_segments_lie_on_rendered_geometry(fixture: Path):
     assert not offences, (
         f"{fixture.name}: motion path contains off-piste segments not on "
         f"any rendered metro-line edge:\n  " + "\n  ".join(offences[:5])
+    )
+
+
+def _edge_disjoint_coverage(graph) -> tuple[set[int], set[int]]:
+    """Return (covered, all) edge-id sets over the animation path enumeration.
+
+    Rebuilds the per-line adjacency exactly as ``_build_line_motion_paths``
+    does, then collects which edges the enumerated ball paths traverse.
+    ``all`` counts every line-edge whose line participates in animation and
+    whose line has a root to start a path from.
+    """
+    from nf_metro.render.animate import _find_edge_disjoint_paths
+
+    edges_by_line: dict[str, list] = {}
+    for edge in graph.edges:
+        edges_by_line.setdefault(edge.line_id, []).append(edge)
+
+    covered: set[int] = set()
+    all_edges: set[int] = set()
+    for line_id, edges in edges_by_line.items():
+        if line_id not in graph.lines:
+            continue
+        adj: dict[str, list[tuple[str, object]]] = {}
+        incoming: set[str] = set()
+        for edge in edges:
+            adj.setdefault(edge.source, []).append((edge.target, edge))
+            incoming.add(edge.target)
+        roots = set(adj.keys()) - incoming
+        if not roots:
+            continue
+        for edge in edges:
+            all_edges.add(id(edge))
+        for path in _find_edge_disjoint_paths(roots, adj):
+            for edge in path:
+                covered.add(id(edge))
+    return covered, all_edges
+
+
+@pytest.mark.parametrize("fixture", ANIMATION_FIXTURES, ids=ANIMATION_FIXTURE_IDS)
+def test_every_line_edge_gets_an_animated_ball(fixture: Path):
+    """Every line-edge must be traversed by at least one enumerated ball path.
+
+    A fork reachable only through a non-first branch at an earlier fork
+    must get a variant path, so none of its edges drop out of the
+    animation.
+    """
+    graph = parse_metro_mermaid(fixture.read_text())
+    graph.source_dir = str(fixture.parent)
+    compute_layout(graph)
+
+    covered, all_edges = _edge_disjoint_coverage(graph)
+    missing = all_edges - covered
+    assert not missing, (
+        f"{fixture.name}: {len(missing)} line-edge(s) are never traversed by "
+        f"any animated ball path"
     )
 
 


### PR DESCRIPTION
## Summary
- `_variant_path` (src/nf_metro/render/animate.py) tries the existing canonical first-branch prefix walk from a line's root to a fork node, and falls back to a BFS over the full adjacency only when that walk dead-ends before reaching the fork
- Fixes forks that sit behind a different fork's non-canonical branch (e.g. a fork downstream of a dead-end-sink branch), where the forced alternate edge was previously silently never added to any ball's motion path
- Adds `riboseq_metro.mmd` to `ANIMATION_FIXTURES` and a new regression test asserting every line-edge appears in at least one animated ball's motion path; this also recovers 3 previously-dropped edges on the existing `genomeassembly` fixture

Fixes #1941

## Test plan
- [x] Targeted tests pass locally (including new invariant test); CI matrix runs the full suite
- [x] ruff check + ruff format clean on changed files
- [ ] Runtime validator: not applicable (class-c path-enumeration defect, no geometric property to guard; the new invariant test is the regression lock)
- [x] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1942/): no static-render regressions; separately confirmed in a real browser that the fix moves balls through the previously-dead ORF-calling and Translational-efficiency lanes on riboseq_metro.mmd
- [x] Render-preview verdict: no visual changes to the static gallery corpus (animate mode isn't part of the gallery snapshot set)