### PR TITLE
refactor(render): remove unreachable mutable theme branch

### DIFF
--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -4033,7 +4033,7 @@ def _station_group_attrs(
     }
 
 
-def _muted_line_theme(theme: Theme) -> Theme:
+def _muted_line_theme(theme: FrozenRecord) -> FrozenRecord:
     """Return *theme* with every line-identity stroke/text set to the muted grey.
 
     Station stroke, marker outline, terminus icon stroke, and label/terminus
@@ -4042,9 +4042,7 @@ def _muted_line_theme(theme: Theme) -> Theme:
     background, not line identity).
 
     A render plan carries its theme as a :class:`FrozenRecord`, which cannot be
-    :func:`dataclasses.replace`-d, so that case rebuilds the record directly.
-    Both branches read the same override map, so neither representation can be
-    left behind when a field joins the muted set.
+    :func:`dataclasses.replace`-d, so rebuild the record with the muted fields.
     """
     muted = theme.muted_line_color
     overrides: dict[str, Any] = {
@@ -4054,16 +4052,16 @@ def _muted_line_theme(theme: Theme) -> Theme:
         "terminus_font_color": muted,
         "label_color": muted,
     }
-    if isinstance(theme, FrozenRecord):
-        entries = tuple((k, overrides.get(k, v)) for k, v in theme.values.entries)
-        return cast(Theme, FrozenRecord(kind=theme.kind, values=FrozenMap(entries)))
-    return replace(theme, **overrides)
+    entries = tuple(
+        (key, overrides.get(key, value)) for key, value in theme.values.entries
+    )
+    return FrozenRecord(kind=theme.kind, values=FrozenMap(entries))
 
 
 def _render_stations(
     d: draw.Drawing,
     graph: MetroGraph,
-    theme: Theme,
+    theme: FrozenRecord,
     station_offsets: dict[tuple[str, str], float] | None = None,
     positive_fan: set[str] | None = None,
     inactive_line_ids: frozenset[str] = frozenset(),
@@ -4082,15 +4080,16 @@ def _render_stations(
     """
     if positive_fan is None:
         positive_fan = tb_positive_fan_sections(graph)
-    muted_theme = _muted_line_theme(theme)
+    theme_view = cast(Theme, theme)
+    muted_theme = cast(Theme, _muted_line_theme(theme))
     for station in graph.stations.values():
         if station.is_port or station.is_hidden:
             continue
         muted = station_is_muted(graph, station.id, inactive_line_ids)
-        station_theme = muted_theme if muted else theme
+        station_theme = muted_theme if muted else theme_view
         if graph.embed_manifest:
             attrs = _station_group_attrs(
-                graph, theme, station, station_offsets, positive_fan
+                graph, theme_view, station, station_offsets, positive_fan
             )
             g = draw.Group(**attrs)
             _render_station_into(

--- a/tests/test_inactive_lines.py
+++ b/tests/test_inactive_lines.py
@@ -18,7 +18,7 @@ from nf_metro.render.constants import (
     effective_line_color,
     station_is_muted,
 )
-from nf_metro.render.plan import FrozenRecord
+from nf_metro.render.plan import FrozenRecord, freeze_render_value
 from nf_metro.render.svg import _muted_line_theme, render_svg
 from nf_metro.themes import NFCORE_DARK_THEME, resolve_theme
 
@@ -563,11 +563,10 @@ def test_render_svg_unknown_inactive_line_raises():
     assert "nope" in str(exc.value)
 
 
-def test_muted_theme_overrides_every_field_on_a_plain_theme():
-    # A render always passes the plan's FrozenRecord theme; a dataclass Theme
-    # takes the dataclasses.replace path instead.
-    muted = _muted_line_theme(NFCORE_DARK_THEME)
-    assert not isinstance(muted, FrozenRecord)
+def test_muted_theme_overrides_every_field_on_a_frozen_theme():
+    frozen = freeze_render_value(NFCORE_DARK_THEME)
+    assert isinstance(frozen, FrozenRecord)
+    muted = _muted_line_theme(frozen)
     assert muted.station_stroke == MUTED
     assert muted.marker_stroke == MUTED
     assert muted.terminus_stroke == MUTED


### PR DESCRIPTION
## Summary

- narrow `_muted_line_theme` to the frozen theme representation used by `RenderPlan`
- remove the unreachable mutable `Theme` / `dataclasses.replace` branch
- update the direct muting test to freeze the theme through the production `freeze_render_value` path

The terminus colour assertion described in the other half of #1904 is already pinned to a literal on `main`, so this addresses the remaining dead-path cleanup.

Closes #1904.

## Test plan

- `pytest -q tests/test_inactive_lines.py` — 28 passed
- render-focused suite (`inactive_lines`, `render`, `render_plan`, `manifest`, `manifest_standalone`, `markers`, `interchange`, `rail_mode`) — 1,249 passed
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy` — 118 source files clean
- gallery build on base and branch — 346 artifacts each
- render diff — no render changes detected
