### PR TITLE
ci: test Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         split: [1, 2, 3]
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        # The supported bounds only: requires-python's floor and the newest
+        # release. A break that hits 3.12 or 3.13 alone, and neither end, is
+        # rare enough not to be worth tripling the matrix for.
+        python-version: ["3.11", "3.14"]
         split: [1, 2, 3]
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [


### PR DESCRIPTION
Test Python 3.14 and don't bother testing the versions between the span to save CI time.

<details>
<summary>Details</summary>

`requires-python = ">=3.11"` carries no upper bound, so pip already installs nf-metro on 3.14. Nothing tested it and no classifier claimed it, so the newest Python sat in the awkward middle: installable, unverified, unsupported on paper.

Two changes:

- The test matrix now runs the supported **bounds** — 3.11 and 3.14 — rather than 3.11, 3.12 and 3.13. A break that hits 3.12 or 3.13 alone, and neither end, is rare enough not to be worth three versions times three test splits.
- `"3.14"` joins the classifier list, so what the package claims matches what CI proves.

Net effect on CI: nine test jobs become six, and the newest Python is covered where it previously was not.

No dependency stands in the way. `resvg-py` ships `cp314` and `cp315` wheels (including free-threaded), `pillow` and `networkx` both classify for 3.14, and `click`, `lark` and `drawsvg` carry no ceiling.

Jobs that pin a single version (lint, format, wheel smoke on 3.12; routing gate coverage on 3.11) are untouched — this only changes the matrix.

## Two things for the reviewer

The matrix is `fail-fast: true`, so if 3.14 turns up a genuine incompatibility it takes 3.11 down with it rather than failing alone. That is the existing setting and I have left it, but it is worth knowing before this merges.

I did not run the suite on 3.14 locally — this PR exists so CI answers that. If it comes back red, the fix belongs here rather than in the classifier.

## Out of scope

`npx actions-up --dry-run` reports 40 action versions behind across the workflow files, and `zizmor` reports 13 medium findings (jobs with no `permissions:` block). Both are pre-existing and unrelated: zizmor returns the same 20 findings with and without this change. Happy to do either as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
