### PR TITLE
fix(render): grow canvas to fit the map title (#1553)

### DIFF
--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -234,6 +234,15 @@ def title_baseline_y(title_font_size: float) -> float:
     return max(TITLE_Y_OFFSET, title_font_size * TITLE_ASCENT_RATIO)
 
 
+TITLE_CANVAS_SAFETY_MARGIN: float = 4.0
+"""Slack added past the title's true glyph advance when sizing the canvas.
+
+The canvas width is grown to hold the title using the deterministic fallback
+advance, which approximates the browser's real bold font metrics; this covers
+the small discrepancy so a title never touches the right edge.
+"""
+
+
 WATERMARK_FONT_SIZE: int = 8
 """Font size for the attribution watermark."""
 

--- a/src/nf_metro/render/plan.py
+++ b/src/nf_metro/render/plan.py
@@ -203,6 +203,7 @@ class RenderPlan:
     debug: bool
     chrome_css: bool
     bare: bool
+    draws_standalone_title: bool
     inactive_line_ids: frozenset[str] = frozenset()
 
     @property

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -192,6 +192,7 @@ from nf_metro.render.constants import (
     SVG_CURVE_RADIUS,
     TERMINUS_FONT_COLOR,
     TEXT_VCENTER_DY,
+    TITLE_CANVAS_SAFETY_MARGIN,
     WATERMARK_BARE_X_INSET,
     WATERMARK_FILL,
     WATERMARK_FONT_SIZE,
@@ -2377,6 +2378,20 @@ def _build_render_plan_scaled(
     # the watermark text.
     auto_width = max_x + (0.0 if bare else padding)
     auto_height = max_y + WATERMARK_Y_INSET * 2 + WATERMARK_FONT_SIZE
+
+    # The title is authored text drawn at x=padding but never folded into the
+    # content extent, so a title wider than the map is clipped at the right
+    # edge.  Grow the canvas to its true glyph advance plus a small margin,
+    # under the same condition that draws it (see the Title/Logo block).
+    if not bare and graph.title and not logo_in_legend and not show_logo:
+        title_advance = DEFAULT_TEXT_METRICS.advance(
+            graph.title,
+            text_style(theme.title_font_size, "bold"),
+            TextRole.TITLE,
+        )
+        auto_width = max(
+            auto_width, padding + title_advance + TITLE_CANVAS_SAFETY_MARGIN
+        )
 
     # A relocated header may sit past the box; let it use the margins already
     # added above and only stretch the canvas for the part that overflows them,

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -751,6 +751,7 @@ class _FinalPublishedGeometry(FinalCanvasGeometry):
     debug: bool
     chrome_css: bool
     bare: bool
+    draws_standalone_title: bool
 
 
 _FINAL_RENDER_PLAN_FINGERPRINT_SOURCES = {
@@ -791,6 +792,7 @@ _FINAL_RENDER_PLAN_FINGERPRINT_SOURCES = {
     "debug": "published.debug",
     "chrome_css": "published.chrome_css",
     "bare": "published.bare",
+    "draws_standalone_title": "published.draws_standalone_title",
     "inactive_line_ids": "inactive_line_ids",
 }
 
@@ -2344,6 +2346,13 @@ def _build_render_plan_scaled(
     logo_in_legend = show_logo and effective_legend_position != "none"
     legend_logo_size = (logo_w, logo_h) if logo_in_legend else None
 
+    # Whether this render draws the map title as standalone chrome: the one
+    # predicate that both the canvas-sizing term and the title-draw block read,
+    # so the two cannot drift and reintroduce a clipped or unmeasured title.
+    draws_standalone_title = (
+        not bare and bool(graph.title) and not logo_in_legend and not show_logo
+    )
+
     legend_x, legend_y, legend_w, legend_h, show_legend = _position_legend(
         graph,
         theme,
@@ -2381,9 +2390,8 @@ def _build_render_plan_scaled(
 
     # The title is authored text drawn at x=padding but never folded into the
     # content extent, so a title wider than the map is clipped at the right
-    # edge.  Grow the canvas to its true glyph advance plus a small margin,
-    # under the same condition that draws it (see the Title/Logo block).
-    if not bare and graph.title and not logo_in_legend and not show_logo:
+    # edge.  Grow the canvas to its true glyph advance plus a small margin.
+    if draws_standalone_title:
         title_advance = DEFAULT_TEXT_METRICS.advance(
             graph.title,
             text_style(theme.title_font_size, "bold"),
@@ -2464,6 +2472,7 @@ def _build_render_plan_scaled(
         debug=debug,
         chrome_css=chrome_css,
         bare=bare,
+        draws_standalone_title=draws_standalone_title,
     )
     route_plan = realise_route_reservations(
         route_plan,
@@ -2547,6 +2556,7 @@ def _build_render_plan_scaled(
         debug=published_geometry.debug,
         chrome_css=published_geometry.chrome_css,
         bare=published_geometry.bare,
+        draws_standalone_title=published_geometry.draws_standalone_title,
         inactive_line_ids=inactive_line_ids,
     ), route_plan
 
@@ -2670,7 +2680,7 @@ def _emit_render_plan(
                 )
             else:
                 _render_logo(d, effective_logo, logo_x, logo_y, logo_w, logo_h)
-        elif graph.title and not logo_in_legend:
+        elif plan.draws_standalone_title:
             d.append(
                 draw.Text(
                     graph.title,

--- a/tests/test_render_plan.py
+++ b/tests/test_render_plan.py
@@ -45,7 +45,7 @@ def _plan(path: str) -> tuple[MetroGraph, RenderPlan]:
             "examples/topologies/lr_perp_top_entry_bottom_exit.mmd",
             9,
             8,
-            (373, 628),
+            (580, 628),
         ),
         ("examples/rail_mode.mmd", 11, 32, (531, 965)),
         ("examples/file_icons.mmd", 9, 8, (540, 419)),

--- a/tests/test_title_canvas_fit.py
+++ b/tests/test_title_canvas_fit.py
@@ -1,0 +1,63 @@
+"""The canvas is wide enough to hold the map title.
+
+The title is authored text drawn at ``x=padding``; a canvas sized from section
+content alone clips it at the right edge with no warning. These tests hold that
+the title's drawn right edge stays within the canvas width.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.api import prepare_graph
+from nf_metro.render.svg import RenderPlan, build_render_plan
+from nf_metro.text_metrics import (
+    DEFAULT_TEXT_METRICS,
+    MetricsFace,
+    TextRole,
+    metrics_face_context,
+    text_style,
+)
+from nf_metro.themes import resolve_theme
+
+ROOT = Path(__file__).parents[1]
+
+# Both narrow-map reproducers from the issue, plus a wide gallery fixture whose
+# content already exceeds its title, so the invariant is exercised on a map the
+# fix must leave alone as well as on the two it must grow.
+TITLE_FIXTURES = (
+    "examples/topologies/lr_perp_top_entry_bottom_exit.mmd",
+    "examples/topologies/lr_to_tb_top_drop_two_lines.mmd",
+    "examples/topologies/convergent_offrow_exit_climb.mmd",
+)
+
+
+def _plan(path: Path) -> RenderPlan:
+    graph = prepare_graph(path.read_text(), source_dir=str(path.parent))
+    return build_render_plan(graph, resolve_theme(None, graph))
+
+
+def _title_right_edge(plan: RenderPlan) -> float:
+    """Right edge of the title as drawn: ``x=padding`` plus its true advance."""
+    with metrics_face_context(MetricsFace.FALLBACK):
+        advance = DEFAULT_TEXT_METRICS.advance(
+            plan.graph.title,
+            text_style(plan.theme.title_font_size, "bold"),
+            TextRole.TITLE,
+        )
+    return plan.padding + advance
+
+
+@pytest.mark.parametrize("name", TITLE_FIXTURES)
+def test_title_fits_within_canvas_width(name: str) -> None:
+    plan = _plan(ROOT / name)
+    assert plan.graph.title, f"{name} carries no title to test"
+    assert not plan.show_logo and not plan.logo_in_legend and not plan.bare, (
+        f"{name} does not draw a standalone title"
+    )
+    assert _title_right_edge(plan) <= plan.svg_width, (
+        f"{name} clips its title: right edge {_title_right_edge(plan):.1f} "
+        f"exceeds canvas width {plan.svg_width}"
+    )


### PR DESCRIPTION
## Summary
- A `%%metro title:` wider than the canvas was silently clipped at the SVG's right edge on a narrow map, with no warning and no error.
- The canvas-width computation in `_build_render_plan_scaled` (`render/svg.py`) now folds in a title-width term, sized from the true glyph advance (`DEFAULT_TEXT_METRICS.advance`, not the inflated `reserve_width` clearance policy) plus a small fixed safety margin (`TITLE_CANVAS_SAFETY_MARGIN = 4.0`), guarded by the same condition under which the title is actually drawn.
- The "does this render draw a standalone title" predicate, previously expressed independently in two places (canvas sizing and title drawing), is now computed once and stored on `RenderPlan.draws_standalone_title`, so the two sites cannot drift apart.
- No layout/routing geometry is touched: station coordinates and route polylines are unchanged. This is a render-only sizing fix.
- Expect roughly ~40 of the 316 title-bearing corpus fixtures to widen in the render-diff preview below - these are the genuinely-clipped ones; this is the intended fix, not a regression.

Fixes #1553

## Test plan
- [x] New invariant test (`tests/test_title_canvas_fit.py`) fails on `main`, passes on this branch
- [x] Targeted tests pass locally (`test_title_canvas_fit.py`, `test_render_plan.py`, `test_corridor_cohort_integration.py`, `-k title`); CI matrix runs the full suite
- [x] `ruff check` + `ruff format --check` clean on changed files
- [ ] Runtime validator: deliberately not added - grow-canvas is fail-open by construction (can only widen, never clip), so a guard adds no correctness value here
- [ ] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1975/)
- [ ] Render-preview verdict: pending CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)