### PR TITLE
fix(parser): apply --line-spread at parse time so it matches the directive

### DIFF
--- a/src/nf_metro/api.py
+++ b/src/nf_metro/api.py
@@ -221,6 +221,9 @@ def _prepare_graph_state(
         caller_line_order=(
             caller_line_order if is_line_order(caller_line_order) else None
         ),
+        caller_line_spread=(
+            LineSpread(line_spread) if line_spread is not None else None
+        ),
         _layout_commitments=layout_commitments,
     )
     if not graph.stations:
@@ -248,8 +251,6 @@ def _prepare_graph_state(
                 setattr(graph, attr, str(candidate))
             elif logo_is_resolvable(raw):
                 setattr(graph, attr, raw)
-    if line_spread is not None:
-        graph.line_spread = LineSpread(line_spread)
     if logo is not None:
         graph.logo_path = str(logo)
     if legend is not None:

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -50,6 +50,7 @@ from nf_metro.parser.grammar import (
 from nf_metro.parser.model import (
     UNANNOTATED_LINE_ID,
     Edge,
+    LineSpread,
     MetroGraph,
     Section,
     Station,
@@ -237,6 +238,7 @@ def parse_metro_mermaid(
     process_scope: str | None = None,
     caller_line_order: LineOrder | None = None,
     *,
+    caller_line_spread: LineSpread | None = None,
     _layout_commitments: LayoutCommitmentOverlay | None = None,
 ) -> MetroGraph:
     """Parse a Mermaid graph definition with %%metro directives.
@@ -256,6 +258,12 @@ def parse_metro_mermaid(
 
     ``caller_line_order`` is the validated caller policy whose provenance must
     be captured before layout inference.
+
+    ``caller_line_spread`` is the ``--line-spread`` CLI flag's graph-wide
+    default. When not ``None`` it overrides any ``%%metro line_spread:`` default
+    directive and, unlike a post-parse assignment, is visible to the parse-time
+    layout inference that reads ``graph.line_spread`` (interchange inference
+    skips rail sections). It never touches ``line_spread_overrides``.
     """
     if caller_line_order is not None and not is_line_order(caller_line_order):
         raise ValueError(f"unsupported caller line order {caller_line_order!r}")
@@ -268,6 +276,7 @@ def parse_metro_mermaid(
         auto_process,
         process_scope,
         caller_line_order,
+        caller_line_spread=caller_line_spread,
         layout_commitments=_layout_commitments,
     )
     return graph
@@ -304,6 +313,7 @@ def _finalize_graph(
     process_scope: str | None = None,
     caller_line_order: LineOrder | None = None,
     *,
+    caller_line_spread: LineSpread | None = None,
     layout_commitments: LayoutCommitmentOverlay | None = None,
 ) -> None:
     """Validate, run the post-parse resolution, and apply buffered metadata."""
@@ -331,6 +341,12 @@ def _finalize_graph(
         if layout_commitments is not None
         else AppliedLayoutCommitments()
     )
+
+    # The --line-spread flag's graph-wide default wins over the %%metro
+    # line_spread: default directive, and must land before inference so the
+    # rail-section check in interchange inference reads the caller's value.
+    if caller_line_spread is not None:
+        graph.line_spread = caller_line_spread
 
     # Layout inference (interchange expansion, section grids, port/junction
     # resolution) assumes the graph is a DAG. A cyclic graph is rejected at the

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -237,8 +237,8 @@ def parse_metro_mermaid(
     auto_process: bool | None = None,
     process_scope: str | None = None,
     caller_line_order: LineOrder | None = None,
-    *,
     caller_line_spread: LineSpread | None = None,
+    *,
     _layout_commitments: LayoutCommitmentOverlay | None = None,
 ) -> MetroGraph:
     """Parse a Mermaid graph definition with %%metro directives.
@@ -312,8 +312,8 @@ def _finalize_graph(
     auto_process: bool | None = None,
     process_scope: str | None = None,
     caller_line_order: LineOrder | None = None,
-    *,
     caller_line_spread: LineSpread | None = None,
+    *,
     layout_commitments: LayoutCommitmentOverlay | None = None,
 ) -> None:
     """Validate, run the post-parse resolution, and apply buffered metadata."""

--- a/tests/test_line_spread_parse_timing.py
+++ b/tests/test_line_spread_parse_timing.py
@@ -1,0 +1,42 @@
+"""Regression lock for #1967: the ``--line-spread`` CLI flag and the
+``%%metro line_spread:`` directive produce the same graph for identical intent.
+
+Parse-time readers of ``graph.line_spread`` (interchange inference skips rail
+sections) must see the caller-supplied spread. On
+``rail_marker_subset_interchange.mmd`` a divergence lets the flag path infer a
+spurious interchange, expanding it into an extra station the directive path
+never gets.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nf_metro.api import _prepare_graph_state
+from nf_metro.parser.model import LineSpread
+
+FIXTURE = (
+    Path(__file__).resolve().parent / "fixtures" / "rail_marker_subset_interchange.mmd"
+)
+
+
+def _interchange_ids(graph):
+    return sorted(ic.node_id for ic in graph.interchanges)
+
+
+def test_cli_flag_and_directive_line_spread_agree():
+    directive_text = FIXTURE.read_text()
+    flag_text = "".join(
+        line
+        for line in directive_text.splitlines(keepends=True)
+        if not line.startswith("%%metro line_spread:")
+    )
+
+    directive_graph = _prepare_graph_state(directive_text)
+    flag_graph = _prepare_graph_state(flag_text, line_spread="rails")
+
+    assert directive_graph.line_spread is LineSpread.RAILS
+    assert flag_graph.line_spread is LineSpread.RAILS
+
+    assert len(flag_graph.stations) == len(directive_graph.stations)
+    assert _interchange_ids(flag_graph) == _interchange_ids(directive_graph)


### PR DESCRIPTION
## Summary
- The `--line-spread` CLI flag was applied post-parse (`api.py`), while the equivalent `%%metro line_spread:` directive is applied during parsing. Parse-time interchange inference (`infer_interchanges`, which skips rail sections via `graph.line_spread`) therefore saw different values depending on which spelling was used, producing different graphs for identical intent.
- `parse_metro_mermaid`/`_finalize_graph` now accept an explicit `caller_line_spread` parameter and apply it before parse-time layout inference runs, mirroring the existing `caller_line_order` threading pattern. The post-parse assignment in `api.py` is removed; `graph.line_spread` remains a populated field for its many layout/render-time readers.
- Directive-only graphs are unaffected: render output is byte-identical before and after this change.

Fixes #1967

## Test plan
- [x] New regression test (`tests/test_line_spread_parse_timing.py`) confirmed red on `main` (CLI-flag path produced 8 stations with a spurious inferred interchange vs. 7 for the directive path on `tests/fixtures/rail_marker_subset_interchange.mmd`), green after the fix
- [x] Targeted tests pass locally (`test_line_spread_parse_timing`, `test_parser`, `test_rail_mode`, `test_cli`, `test_api`, `test_parser_grammar` - 827 passed); CI matrix runs the full suite
- [x] `ruff check` + `ruff format --check` clean on changed files
- [ ] Runtime validator: not applicable - this is a parse-time consistency defect, not a layout geometry property; the regression test is the lock
- [ ] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1978/)
- [ ] Render-preview verdict: pending CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)