### PR TITLE
fix: consolidate terminus flow context derivation in svg.py (#1976)

### DIFF
--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -527,11 +527,11 @@ def _terminus_stacked_pad(theme: Theme, has_stacked: bool) -> float:
 
 @dataclass(frozen=True)
 class _TerminusFlowContext:
-    """Flow-axis facts shared by every terminus-icon placement computation.
+    """Flow-axis facts for placing a terminus station's icon(s).
 
-    ``section_dir``, ``is_vertical_flow``, ``is_source``, and ``flow_sign``
-    are all derived from ``section`` and ``is_source`` alone; bundling them
-    avoids re-deriving the same tuple at each call site.
+    ``section_dir`` derives from ``section``; ``is_vertical_flow`` from
+    ``section_dir``; ``is_source`` from the station's incoming edges; and
+    ``flow_sign`` from ``section_dir`` and ``is_source``.
     """
 
     section: Section | None

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -525,6 +525,38 @@ def _terminus_stacked_pad(theme: Theme, has_stacked: bool) -> float:
     return theme.terminus_width * FILES_ICON_OFFSET_RATIO if has_stacked else 0.0
 
 
+@dataclass(frozen=True)
+class _TerminusFlowContext:
+    """Flow-axis facts shared by every terminus-icon placement computation.
+
+    ``section_dir``, ``is_vertical_flow``, ``is_source``, and ``flow_sign``
+    are all derived from ``section`` and ``is_source`` alone; bundling them
+    avoids re-deriving the same tuple at each call site.
+    """
+
+    section: Section | None
+    section_dir: str
+    is_vertical_flow: bool
+    is_source: bool
+    flow_sign: float
+
+
+def _terminus_flow_context(station: Station, graph: MetroGraph) -> _TerminusFlowContext:
+    """Build the flow-axis context for one of *station*'s terminus icons."""
+    section = graph.sections.get(station.section_id) if station.section_id else None
+    section_dir = section.direction if section else "LR"
+    is_vertical_flow = lanes_run_along_x(section_dir)
+    is_source = not graph.edges_to(station.id)
+    flow_sign = _terminus_icon_flow_sign(section_dir, is_source)
+    return _TerminusFlowContext(
+        section=section,
+        section_dir=section_dir,
+        is_vertical_flow=is_vertical_flow,
+        is_source=is_source,
+        flow_sign=flow_sign,
+    )
+
+
 def _icon_obstacles_by_station(
     graph: MetroGraph,
     theme: Theme,
@@ -551,7 +583,6 @@ def _icon_obstacles_by_station(
         # box that always assumed a horizontal row sat beside the wrong
         # axis on a vertical-flow terminus (a line could rake the real
         # icon while the box reported clear).
-        section = graph.sections.get(station.section_id) if station.section_id else None
         line_offs = [
             station_offsets.get((station.id, lid), 0.0)
             for lid in graph.station_lines(station.id)
@@ -579,14 +610,11 @@ def _icon_obstacles_by_station(
         # the caption above the icon; everything else hangs it below.
         caption_line_count = station.terminus_caption_line_count
         if caption_line_count:
-            section_dir = section.direction if section else "LR"
-            is_vertical_flow = lanes_run_along_x(section_dir)
-            is_source = not graph.edges_to(station.id)
-            flow_sign = _terminus_icon_flow_sign(section_dir, is_source)
+            ctx = _terminus_flow_context(station, graph)
             caption_extent = ICON_NAME_GAP + (
                 caption_line_count * theme.label_font_size * ICON_NAME_FONT_SCALE
             )
-            if _terminus_caption_hangs_down(is_vertical_flow, flow_sign):
+            if _terminus_caption_hangs_down(ctx.is_vertical_flow, ctx.flow_sign):
                 y_max += caption_extent
             else:
                 y_min -= caption_extent
@@ -4373,20 +4401,17 @@ def _terminus_icon_centers_for(
     if not station.is_terminus or not station.terminus_labels:
         return []
 
-    section = graph.sections.get(station.section_id) if station.section_id else None
-    is_source = not graph.edges_to(station.id)
-    section_dir = section.direction if section else "LR"
-    is_vertical_flow = lanes_run_along_x(section_dir)
+    ctx = _terminus_flow_context(station, graph)
 
     r = theme.station_radius
     icon_gap = r + ICON_STATION_GAP
     icon_half_w = theme.terminus_width / 2
     icon_half_h = theme.terminus_height / 2
-    icon_half_flow = icon_half_h if is_vertical_flow else icon_half_w
+    icon_half_flow = icon_half_h if ctx.is_vertical_flow else icon_half_w
 
     bundle_center = (min_off + max_off) / 2
 
-    icon_step, _ = _terminus_icon_marching(theme, station, is_vertical_flow)
+    icon_step, _ = _terminus_icon_marching(theme, station, ctx.is_vertical_flow)
 
     is_rail = graph.station_is_rail(station.id)
     offtrack_nub_lift = (
@@ -4397,8 +4422,8 @@ def _terminus_icon_centers_for(
 
     return _terminus_icon_centers(
         station,
-        section_dir,
-        is_source,
+        ctx.section_dir,
+        ctx.is_source,
         len(station.terminus_labels),
         icon_gap + icon_half_flow + offtrack_nub_lift,
         icon_step,
@@ -4481,13 +4506,8 @@ def _render_terminus_icons(
     axis (a horizontal row for LR/RL, a vertical stack for TB/BT), with
     the first icon closest to the station pill.
     """
-    section: Section | None = (
-        graph.sections.get(station.section_id) if station.section_id else None
-    )
-    section_dir = section.direction if section else "LR"
-    is_vertical_flow = lanes_run_along_x(section_dir)
-    is_source = not graph.edges_to(station.id)
-    flow_sign = _terminus_icon_flow_sign(section_dir, is_source)
+    ctx = _terminus_flow_context(station, graph)
+    section = ctx.section
     icon_half_w = theme.terminus_width / 2
     icon_half_h = theme.terminus_height / 2
 
@@ -4498,7 +4518,9 @@ def _render_terminus_icons(
     banners = station.terminus_icon_banners or [False] * len(station.terminus_labels)
 
     caption_font_size = theme.label_font_size * ICON_NAME_FONT_SCALE
-    icon_step, name_widths = _terminus_icon_marching(theme, station, is_vertical_flow)
+    icon_step, name_widths = _terminus_icon_marching(
+        theme, station, ctx.is_vertical_flow
+    )
 
     centers = _terminus_icon_centers_for(station, graph, theme, min_off, max_off)
 
@@ -4523,11 +4545,11 @@ def _render_terminus_icons(
 
         # Clamp to stay within the section bbox, on whichever axis the
         # icons march along.
-        if section and is_vertical_flow and section.bbox_h > 0:
+        if section and ctx.is_vertical_flow and section.bbox_h > 0:
             top = section.bbox_y + icon_half_h + ICON_BBOX_MARGIN
             bottom = section.bbox_y + section.bbox_h - icon_half_h - ICON_BBOX_MARGIN
             icon_cy = max(top, min(icon_cy, bottom))
-        elif section and not is_vertical_flow and section.bbox_w > 0:
+        elif section and not ctx.is_vertical_flow and section.bbox_w > 0:
             icon_right = (
                 section.bbox_x + section.bbox_w - icon_half_w - ICON_BBOX_MARGIN
             )
@@ -4560,7 +4582,7 @@ def _render_terminus_icons(
             render_folder_icon(d, **common)
         elif icon_type == ICON_TYPE_FILES:
             back_dx_sign, back_dy_sign = (
-                (1.0, flow_sign) if is_vertical_flow else (flow_sign, -1.0)
+                (1.0, ctx.flow_sign) if ctx.is_vertical_flow else (ctx.flow_sign, -1.0)
             )
             render_files_icon(
                 d,
@@ -4586,7 +4608,7 @@ def _render_terminus_icons(
         # inside the icon stays readable.
         if name:
             caption_hangs_down = _terminus_caption_hangs_down(
-                is_vertical_flow, flow_sign
+                ctx.is_vertical_flow, ctx.flow_sign
             )
             # A stacked-files icon's back sheet peeks past the nominal edge
             # along the flow axis -- toward the caption for a vertical flow, but
@@ -4594,7 +4616,7 @@ def _render_terminus_icons(
             # vertical flow needs the extra clearance to keep the caption off
             # the drawn icon.
             stacked_pad = _terminus_stacked_pad(
-                theme, is_vertical_flow and icon_type == ICON_TYPE_FILES
+                theme, ctx.is_vertical_flow and icon_type == ICON_TYPE_FILES
             )
             icon_edge_gap = theme.terminus_height / 2 + stacked_pad + ICON_NAME_GAP
             stagger_step = caption_font_size * 1.4

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -444,93 +444,6 @@ def test_font_scale_rails_source_icon_fits_section_bbox():
     )
 
 
-_LR_TERMINUS_MMD = """%%metro line: main | Main | #4CAF50
-%%metro files: reads_in | FASTQ
-%%metro file: report_out | HTML
-graph LR
-    subgraph sec [Section]
-        reads_in[ ]
-        step[Step]
-        report_out[ ]
-        reads_in -->|main| step
-        step -->|main| report_out
-    end
-"""
-
-_TB_TERMINUS_MMD = """%%metro line: main | Main | #4CAF50
-%%metro files: reads_in | FASTQ
-%%metro file: report_out | HTML
-graph LR
-    subgraph sec [Section]
-        %%metro direction: TB
-        reads_in[ ]
-        step[Step]
-        report_out[ ]
-        reads_in -->|main| step
-        step -->|main| report_out
-    end
-"""
-
-_RL_TERMINUS_MMD = """%%metro line: main | Main | #4CAF50
-%%metro files: reads_in | FASTQ
-%%metro file: report_out | HTML
-graph LR
-    subgraph sec [Section]
-        %%metro direction: RL
-        reads_in[ ]
-        step[Step]
-        report_out[ ]
-        reads_in -->|main| step
-        step -->|main| report_out
-    end
-"""
-
-
-@pytest.mark.parametrize(
-    ("mmd", "section_dir", "is_vertical_flow"),
-    [
-        (_LR_TERMINUS_MMD, "LR", False),
-        (_TB_TERMINUS_MMD, "TB", True),
-        (_RL_TERMINUS_MMD, "RL", False),
-    ],
-)
-def test_terminus_flow_context_matches_hand_derivation(
-    mmd, section_dir, is_vertical_flow
-):
-    """``_terminus_flow_context`` must reproduce the tuple every call site once
-    derived by hand: ``(section, section_dir, is_vertical_flow, is_source,
-    flow_sign)``.
-
-    Covers a source and a sink terminus in each of a horizontal (LR), a
-    vertical (TB), and a reversed-horizontal (RL) section, since the sign
-    formula (``_terminus_icon_flow_sign``) branches on both axis and
-    direction.
-    """
-    from nf_metro.render.svg import _terminus_flow_context, _terminus_icon_flow_sign
-
-    graph = parse_metro_mermaid(mmd)
-    compute_layout(graph)
-
-    source_station = graph.stations["reads_in"]
-    sink_station = graph.stations["report_out"]
-
-    source_ctx = _terminus_flow_context(source_station, graph)
-    sink_ctx = _terminus_flow_context(sink_station, graph)
-
-    section = graph.sections[source_station.section_id]
-    assert source_ctx.section is section
-    assert sink_ctx.section is section
-    assert source_ctx.section_dir == section_dir
-    assert sink_ctx.section_dir == section_dir
-    assert source_ctx.is_vertical_flow is is_vertical_flow
-    assert sink_ctx.is_vertical_flow is is_vertical_flow
-    assert source_ctx.is_source is True
-    assert sink_ctx.is_source is False
-
-    assert source_ctx.flow_sign == _terminus_icon_flow_sign(section_dir, True)
-    assert sink_ctx.flow_sign == _terminus_icon_flow_sign(section_dir, False)
-
-
 def test_title_baseline_clears_its_own_ascent():
     """An enlarged title drops its baseline instead of ascending off-canvas."""
     from nf_metro.render.constants import (
@@ -1209,6 +1122,31 @@ def test_stacked_files_icon_back_page_does_not_crowd_marker(direction, role):
         f"{direction}/{role}: back page gap {back_gap:.1f} < front page gap "
         f"{front_gap:.1f} -- back page crowds the marker"
     )
+
+
+@pytest.mark.parametrize("direction", ["LR", "RL", "TB", "BT"])
+@pytest.mark.parametrize("role", ["source", "sink"])
+def test_terminus_flow_context_matches_hand_derivation(direction, role):
+    """``_terminus_flow_context`` produces ``(section, section_dir,
+    is_vertical_flow, is_source, flow_sign)`` consistent with the station's
+    section direction and edge topology, for a source and a sink terminus on
+    every flow axis (LR, RL, TB, BT).
+    """
+    from nf_metro.render.svg import _terminus_flow_context, _terminus_icon_flow_sign
+
+    graph = parse_metro_mermaid(_files_terminus_mmd(direction, role))
+    compute_layout(graph)
+    station = graph.stations["t"]
+    section = graph.sections["sec"]
+    is_source = role == "source"
+
+    ctx = _terminus_flow_context(station, graph)
+
+    assert ctx.section is section
+    assert ctx.section_dir == direction
+    assert ctx.is_vertical_flow == lanes_run_along_x(direction)
+    assert ctx.is_source is is_source
+    assert ctx.flow_sign == _terminus_icon_flow_sign(direction, is_source)
 
 
 def test_render_tb_section_file_icon_below_station():

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -444,6 +444,93 @@ def test_font_scale_rails_source_icon_fits_section_bbox():
     )
 
 
+_LR_TERMINUS_MMD = """%%metro line: main | Main | #4CAF50
+%%metro files: reads_in | FASTQ
+%%metro file: report_out | HTML
+graph LR
+    subgraph sec [Section]
+        reads_in[ ]
+        step[Step]
+        report_out[ ]
+        reads_in -->|main| step
+        step -->|main| report_out
+    end
+"""
+
+_TB_TERMINUS_MMD = """%%metro line: main | Main | #4CAF50
+%%metro files: reads_in | FASTQ
+%%metro file: report_out | HTML
+graph LR
+    subgraph sec [Section]
+        %%metro direction: TB
+        reads_in[ ]
+        step[Step]
+        report_out[ ]
+        reads_in -->|main| step
+        step -->|main| report_out
+    end
+"""
+
+_RL_TERMINUS_MMD = """%%metro line: main | Main | #4CAF50
+%%metro files: reads_in | FASTQ
+%%metro file: report_out | HTML
+graph LR
+    subgraph sec [Section]
+        %%metro direction: RL
+        reads_in[ ]
+        step[Step]
+        report_out[ ]
+        reads_in -->|main| step
+        step -->|main| report_out
+    end
+"""
+
+
+@pytest.mark.parametrize(
+    ("mmd", "section_dir", "is_vertical_flow"),
+    [
+        (_LR_TERMINUS_MMD, "LR", False),
+        (_TB_TERMINUS_MMD, "TB", True),
+        (_RL_TERMINUS_MMD, "RL", False),
+    ],
+)
+def test_terminus_flow_context_matches_hand_derivation(
+    mmd, section_dir, is_vertical_flow
+):
+    """``_terminus_flow_context`` must reproduce the tuple every call site once
+    derived by hand: ``(section, section_dir, is_vertical_flow, is_source,
+    flow_sign)``.
+
+    Covers a source and a sink terminus in each of a horizontal (LR), a
+    vertical (TB), and a reversed-horizontal (RL) section, since the sign
+    formula (``_terminus_icon_flow_sign``) branches on both axis and
+    direction.
+    """
+    from nf_metro.render.svg import _terminus_flow_context, _terminus_icon_flow_sign
+
+    graph = parse_metro_mermaid(mmd)
+    compute_layout(graph)
+
+    source_station = graph.stations["reads_in"]
+    sink_station = graph.stations["report_out"]
+
+    source_ctx = _terminus_flow_context(source_station, graph)
+    sink_ctx = _terminus_flow_context(sink_station, graph)
+
+    section = graph.sections[source_station.section_id]
+    assert source_ctx.section is section
+    assert sink_ctx.section is section
+    assert source_ctx.section_dir == section_dir
+    assert sink_ctx.section_dir == section_dir
+    assert source_ctx.is_vertical_flow is is_vertical_flow
+    assert sink_ctx.is_vertical_flow is is_vertical_flow
+    assert source_ctx.is_source is True
+    assert sink_ctx.is_source is False
+
+    assert source_ctx.flow_sign == _terminus_icon_flow_sign(section_dir, True)
+    assert sink_ctx.flow_sign == _terminus_icon_flow_sign(section_dir, False)
+
+
 def test_title_baseline_clears_its_own_ascent():
     """An enlarged title drops its baseline instead of ascending off-canvas."""
     from nf_metro.render.constants import (


### PR DESCRIPTION
## Summary
- Adds a frozen `_TerminusFlowContext` dataclass and a single `_terminus_flow_context(station, graph)` builder in `src/nf_metro/render/svg.py`, consolidating the terminus-icon flow context (`section`, `section_dir`, `is_vertical_flow`, `is_source`, `flow_sign`) that was previously re-derived independently in `_icon_obstacles_by_station`, `_terminus_icon_centers_for`, and `_render_terminus_icons`.
- No production logic changes: all three call sites now build the context once instead of repeating the same derivation. External signatures (consumed by `layout/phases/guards.py`, `layout/phases/off_track.py`, and existing tests) are unchanged.
- Adds a focused regression test (`test_terminus_flow_context_matches_hand_derivation` in `tests/test_render.py`), parametrized over LR/RL/TB/BT sections and source/sink stations, driven off the existing `_files_terminus_mmd` helper.

Fixes #1976

## Test plan
- [x] Targeted tests pass locally (`tests/test_render.py`: 108 passed; `tests/test_layout_invariants.py`: 25998 passed, 56 skipped, 8 xfailed pre-existing); CI matrix runs the full suite
- [x] `ruff check` + `ruff format --check` clean on changed files; `mypy` clean
- [x] Runtime validator: not applicable (class (c) structural refactor, no layout property to guard)
- [x] Byte-identity verified locally: rendered 5 representative fixtures (including terminus/off-track topologies) on base `222e1ec7b` vs candidate and confirmed identical md5 hashes
- [x] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1979/)
- [x] Render-preview verdict: no visual changes detected (all renders match `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)